### PR TITLE
Massive code reformat

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,14 +1,8 @@
 [report]
-omit =
-    */python?.?/*
-    */site-packages/nose/*
-    *__init__*
-
-# Regexes for lines to exclude from consideration
 exclude_lines =
     pragma: no cover
-    raise AssertionError
     raise NotImplementedError
     if __name__ == .__main__.:
-    if not test_mode:
-    os.mkdir
+
+show_missing = true
+skip_covered = true

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+application-import-names = psychrochart
+import-order-style = smarkets
+inline-quotes = double
+max-complexity = 15
+multiline-quotes = double

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 python:
   - "3.6"
   - "3.7"
-  - "3.8"
 
 install:
 #  - pip install psychrochart

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ os: linux
 sudo: false
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 install:
 #  - pip install psychrochart
@@ -15,8 +15,6 @@ install:
   - pip install coveralls==1.7.0
 
 script:
-  - py.test -v --cov psychrochart --cov-report term-missing
-  - pip install scipy==1.2.1
   - py.test -v --cov psychrochart --cov-report term-missing
 after_sucess:
   - coveralls

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,9 @@ include README.md
 
 # Include JSON config files
 recursive-include *.json
+recursive-include psychrochart/ *.py
 
 # Excluded
+global-exclude *.pyc
+global-exclude *.pyd
 global-exclude .DS_Store

--- a/psychrochart/__init__.py
+++ b/psychrochart/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """A library to make psychrometric charts and overlay information in them."""
 
-__version__ = '0.2.6'
+__version__ = "0.2.7"

--- a/psychrochart/__main__.py
+++ b/psychrochart/__main__.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """A library to make psychrometric charts and overlay information in them."""
-from psychrochart.chart import PsychroChart
 import matplotlib.pyplot as plt
+
+from psychrochart.chart import PsychroChart
 
 
 def main():
@@ -9,6 +10,6 @@ def main():
     PsychroChart().plot(ax=plt.gca())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
     plt.show()

--- a/psychrochart/agg.py
+++ b/psychrochart/agg.py
@@ -6,7 +6,7 @@ Import this module first to set matplotlib to use the Agg backend.
 """
 import matplotlib
 
-matplotlib.use('Agg')
+matplotlib.use("Agg")
 
 # noinspection PyPep8
 # noinspection PyUnresolvedReferences

--- a/psychrochart/chart.py
+++ b/psychrochart/chart.py
@@ -3,46 +3,77 @@
 import gc
 import json
 from math import atan2, degrees
+from typing import (
+    Any,
+    AnyStr,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
-from matplotlib import patches, figure
+import numpy as np
+from matplotlib import figure, patches
 from matplotlib.axes import Axes
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
-from matplotlib.legend import Legend  # NOQA
-from matplotlib.path import Path, np
-from typing import Iterable, List, Callable, Union, Dict, AnyStr, Any, Tuple
-from typing import Optional  # NOQA
-try:
-    # noinspection PyPackageRequirements
-    from scipy.spatial import ConvexHull
-    # noinspection PyPackageRequirements
-    from scipy.spatial.qhull import QhullError
-except ImportError:  # pragma: no cover
-    ConvexHull = None
+from matplotlib.legend import Legend
+from matplotlib.path import Path
+from scipy.spatial import ConvexHull
+from scipy.spatial.qhull import QhullError
 
 from psychrochart.equations import (
-    PRESSURE_STD_ATM_KPA, pressure_by_altitude, humidity_ratio,
-    specific_volume, dew_point_temperature, water_vapor_pressure,
-    enthalpy_moist_air, saturation_pressure_water_vapor,
-    dry_temperature_for_enthalpy_of_moist_air, relative_humidity_from_temps,
-    dry_temperature_for_specific_volume_of_moist_air)
+    dew_point_temperature,
+    dry_temperature_for_enthalpy_of_moist_air,
+    dry_temperature_for_specific_volume_of_moist_air,
+    enthalpy_moist_air,
+    humidity_ratio,
+    pressure_by_altitude,
+    PRESSURE_STD_ATM_KPA,
+    relative_humidity_from_temps,
+    saturation_pressure_water_vapor,
+    specific_volume,
+    water_vapor_pressure,
+)
 from psychrochart.util import (
-    load_config, load_zones, mod_color, f_range, solve_curves_with_iteration)
+    f_range,
+    load_config,
+    load_zones,
+    mod_color,
+    solve_curves_with_iteration,
+)
 
 PSYCHRO_CURVES_KEYS = [
-    'constant_dry_temp_data', 'constant_humidity_data',
-    'constant_h_data', 'constant_v_data', 'constant_rh_data',
-    'constant_wbt_data', 'saturation']
+    "constant_dry_temp_data",
+    "constant_humidity_data",
+    "constant_h_data",
+    "constant_v_data",
+    "constant_rh_data",
+    "constant_wbt_data",
+    "saturation",
+]
 
 
-def _between_limits(x_data: List[float], y_data: List[float],
-                    xmin: float, xmax: float,
-                    ymin: float, ymax: float) -> bool:
+def _between_limits(
+    x_data: List[float],
+    y_data: List[float],
+    xmin: float,
+    xmax: float,
+    ymin: float,
+    ymax: float,
+) -> bool:
     data_xmin = min(x_data)
     data_xmax = max(x_data)
     data_ymin = min(y_data)
     data_ymax = max(y_data)
-    if ((data_ymax < ymin) or (data_xmax < xmin) or
-            (data_ymin > ymax) or (data_xmin > xmax)):
+    if (
+        (data_ymax < ymin)
+        or (data_xmax < xmin)
+        or (data_ymin > ymax)
+        or (data_xmin > xmax)
+    ):
         return False
     return True
 
@@ -50,43 +81,48 @@ def _between_limits(x_data: List[float], y_data: List[float],
 class PsychroCurve:
     """Object to store a psychrometric curve for plotting."""
 
-    def __init__(self,
-                 x_data: List[float]=None,
-                 y_data: List[float]=None,
-                 style: dict=None,
-                 type_curve: str=None,
-                 limits: dict=None,
-                 label: str=None, label_loc: float=.75,
-                 logger=None,
-                 verbose: bool=False) -> None:
+    def __init__(
+        self,
+        x_data: List[float] = None,
+        y_data: List[float] = None,
+        style: dict = None,
+        type_curve: str = None,
+        limits: dict = None,
+        label: str = None,
+        label_loc: float = 0.75,
+        logger=None,
+        verbose: bool = False,
+    ) -> None:
         """Create the Psychrocurve object."""
         self._logger = logger
         self._verbose = verbose
-        self.x_data = x_data if x_data else []  # type: List[float]
-        self.y_data = y_data if y_data else []  # type: List[float]
-        self.style = style or {}  # type: dict
+        self.x_data: List[float] = x_data if x_data else []
+        self.y_data: List[float] = y_data if y_data else []
+        self.style: dict = style or {}
         self._type_curve = type_curve
         self._label = label
         self._label_loc = label_loc
         self._limits = limits
-        self._is_patch = (style is not None
-                          and 'facecolor' in style)  # type: bool
+        self._is_patch: bool = (style is not None and "facecolor" in style)
 
     def __bool__(self) -> bool:
         """Return the valid existence of the curve."""
-        if self.x_data is not None and len(self.x_data) > 1 \
-                and self.y_data is not None and len(self.y_data) > 1:
+        if (
+            self.x_data is not None
+            and len(self.x_data) > 1
+            and self.y_data is not None
+            and len(self.y_data) > 1
+        ):
             return True
         return False
 
     def __repr__(self) -> str:
         """Object string representation."""
-        name = 'PsychroZone' if self._is_patch else 'PsychroCurve'
+        name = "PsychroZone" if self._is_patch else "PsychroCurve"
         if self and self.x_data:
-            return '<{} {} values (label: {})>'.format(
-                name, len(self.x_data), self._label)
+            return f"<{name} {len(self.x_data)} values (label: {self._label})>"
         else:
-            return '<Empty {} (label: {})>'.format(name, self._label)
+            return f"<Empty {name} (label: {self._label})>"
 
     def _print_err(self, *args):
         if self._logger is not None:  # pragma: no cover
@@ -102,7 +138,8 @@ class PsychroCurve:
             "x_data": self.x_data,
             "y_data": self.y_data,
             "style": self.style,
-            "label": self._label}
+            "label": self._label,
+        }
 
     def to_json(self) -> str:
         """Return the curve as a JSON string."""
@@ -111,55 +148,71 @@ class PsychroCurve:
     def from_json(self, json_str: AnyStr):
         """Load a curve from a JSON string."""
         data = json.loads(json_str)
-        self.x_data = data['x_data']
-        self.y_data = data['y_data']
-        self.style = data.get('style')
-        self._label = data.get('label')
+        self.x_data = data["x_data"]
+        self.y_data = data["y_data"]
+        self.style = data.get("style")
+        self._label = data.get("label")
         return self
 
     @staticmethod
-    def _annotate_label(ax: Axes, label: AnyStr,
-                        text_x: float, text_y: float, rotation: float,
-                        text_style: Dict):
+    def _annotate_label(
+        ax: Axes,
+        label: AnyStr,
+        text_x: float,
+        text_y: float,
+        rotation: float,
+        text_style: Dict,
+    ):
         if abs(rotation) > 0:
             text_loc = np.array((text_x, text_y))
-            text_style['rotation'] = ax.transData.transform_angles(
-                np.array((rotation,)), text_loc.reshape((1, 2)))[0]
-            text_style['rotation_mode'] = 'anchor'
+            text_style["rotation"] = ax.transData.transform_angles(
+                np.array((rotation,)), text_loc.reshape((1, 2))
+            )[0]
+            text_style["rotation_mode"] = "anchor"
         ax.annotate(label, (text_x, text_y), **text_style)
 
     def plot(self, ax: Axes) -> Axes:
         """Plot the curve."""
         xmin, xmax = ax.get_xlim()
         ymin, ymax = ax.get_ylim()
-        if not self.x_data or not self.y_data or not _between_limits(
-                self.x_data, self.y_data, xmin, xmax, ymin, ymax):
+        if (
+            not self.x_data
+            or not self.y_data
+            or not _between_limits(
+                self.x_data, self.y_data, xmin, xmax, ymin, ymax
+            )
+        ):
             self._print_err(
-                '{} (label:{}) Not between limits ([{}, {}, {}, {}]) '
-                '-> x:{}, y:{}'.format(
-                    self._type_curve, self._label,
-                    xmin, xmax, ymin, ymax, self.x_data, self.y_data))
+                f"{self._type_curve} (label:{self._label}) Not between limits "
+                f"([{xmin}, {xmax}, {ymin}, {ymax}]) "
+                f"-> x:{self.x_data}, y:{self.y_data}"
+            )
             return ax
 
         if self._is_patch and self.y_data is not None:
             assert len(self.y_data) > 2
             verts = list(zip(self.x_data, self.y_data))
-            codes = ([Path.MOVETO] + [Path.LINETO] * (len(self.y_data) - 2)
-                     + [Path.CLOSEPOLY])
+            codes = (
+                [Path.MOVETO]
+                + [Path.LINETO] * (len(self.y_data) - 2)
+                + [Path.CLOSEPOLY]
+            )
             path = Path(verts, codes)
             patch = patches.PathPatch(path, **self.style)
             ax.add_patch(patch)
 
             if self._label is not None:
                 bbox_p = path.get_extents()
-                text_x = .5 * (bbox_p.x0 + bbox_p.x1)
-                text_y = .5 * (bbox_p.y0 + bbox_p.y1)
-                style = {'ha': 'center', 'va': 'center',
-                         "backgroundcolor": [1, 1, 1, .4]}
-                if 'edgecolor' in self.style:
-                    style['color'] = mod_color(self.style['edgecolor'], -25)
-                self._annotate_label(ax, self._label,
-                                     text_x, text_y, 0, style)
+                text_x = 0.5 * (bbox_p.x0 + bbox_p.x1)
+                text_y = 0.5 * (bbox_p.y0 + bbox_p.y1)
+                style = {
+                    "ha": "center",
+                    "va": "center",
+                    "backgroundcolor": [1, 1, 1, 0.4],
+                }
+                if "edgecolor" in self.style:
+                    style["color"] = mod_color(self.style["edgecolor"], -25)
+                self._annotate_label(ax, self._label, text_x, text_y, 0, style)
         else:
             ax.plot(self.x_data, self.y_data, **self.style)
             if self._label is not None:
@@ -167,17 +220,25 @@ class PsychroCurve:
 
         return ax
 
-    def add_label(self, ax: Axes,
-                  text_label: str=None,
-                  va: str=None, ha: str=None,
-                  loc: float=None, **params) -> Axes:
+    def add_label(
+        self,
+        ax: Axes,
+        text_label: str = None,
+        va: str = None,
+        ha: str = None,
+        loc: float = None,
+        **params,
+    ) -> Axes:
         """Annotate the curve with its label."""
         num_samples = len(self.x_data)
         assert num_samples > 1
-        text_style = {'va': 'bottom', 'ha': 'left', 'color': [0., 0., 0.]}
-        loc_f = self._label_loc if loc is None else loc  # type: float
-        label = ((self._label if self._label is not None else '')
-                 if text_label is None else text_label)  # type: str
+        text_style = {"va": "bottom", "ha": "left", "color": [0.0, 0.0, 0.0]}
+        loc_f: float = self._label_loc if loc is None else loc
+        label: str = (
+            (self._label if self._label is not None else "")
+            if text_label is None
+            else text_label
+        )
 
         def _tilt_params(x_data, y_data, idx_0, idx_f):
             delta_x = x_data[idx_f] - self.x_data[idx_0]
@@ -194,16 +255,17 @@ class PsychroCurve:
             rotation, tilt = _tilt_params(self.x_data, self.y_data, 0, 1)
             if abs(rotation) == 90:
                 text_x = self.x_data[0]
-                text_y = (self.y_data[0]
-                          + loc_f * (self.y_data[1] - self.y_data[0]))
-            elif loc_f == 1.:
+                text_y = self.y_data[0] + loc_f * (
+                    self.y_data[1] - self.y_data[0]
+                )
+            elif loc_f == 1.0:
                 if self.x_data[1] > xmax:
                     text_x = xmax
                     text_y = self.y_data[0] + tilt * (xmax - self.x_data[0])
                 else:
                     text_x, text_y = self.x_data[1], self.y_data[1]
-                label += '    '
-                text_style['ha'] = 'right'
+                label += "    "
+                text_style["ha"] = "right"
             else:
                 text_x = self.x_data[0] + loc_f * (xmax - xmin)
                 if text_x < xmin:
@@ -211,17 +273,18 @@ class PsychroCurve:
                 text_y = self.y_data[0] + tilt * (text_x - self.x_data[0])
         else:
             idx = min(num_samples - 2, int(num_samples * loc_f))
-            rotation, tilt = _tilt_params(self.x_data, self.y_data,
-                                          idx, idx + 1)
+            rotation, tilt = _tilt_params(
+                self.x_data, self.y_data, idx, idx + 1
+            )
             text_x, text_y = self.x_data[idx], self.y_data[idx]
-            text_style['ha'] = 'center'
+            text_style["ha"] = "center"
 
-        if 'color' in self.style:
-            text_style['color'] = mod_color(self.style['color'], -25)
+        if "color" in self.style:
+            text_style["color"] = mod_color(self.style["color"], -25)
         if ha is not None:
-            text_style['ha'] = ha
+            text_style["ha"] = ha
         if va is not None:
-            text_style['va'] = va
+            text_style["va"] = va
         if params:
             text_style.update(params)
 
@@ -233,21 +296,13 @@ class PsychroCurve:
 class PsychroCurves:
     """Object to store a list of psychrometric curves for plotting."""
 
-    def __init__(self,
-                 curves: List[PsychroCurve],
-                 family_label: str=None) -> None:
+    def __init__(
+        self, curves: List[PsychroCurve], family_label: str = None
+    ) -> None:
         """Create the Psychrocurves array object."""
-        self.curves = curves  # type: List[PsychroCurve]
-        self.size = len(self.curves)  # type: int
-        self.family_label = family_label  # type: Optional[str]
-
-    # def __len__(self) -> int:
-    #     """Return the # of curves."""
-    #     return self.size
-
-    # def __sizeof__(self) -> int:
-    #     """Return the # of curves."""
-    #     return self.size
+        self.curves: List[PsychroCurve] = curves
+        self.size: int = len(self.curves)
+        self.family_label: Optional[str] = family_label
 
     def __getitem__(self, item) -> PsychroCurve:
         """Get item from the PsychroCurve list."""
@@ -255,8 +310,7 @@ class PsychroCurves:
 
     def __repr__(self) -> str:
         """Object string representation."""
-        return '<{} PsychroCurves (label: {})>'.format(
-            self.size, self.family_label)
+        return f"<{self.size} PsychroCurves (label: {self.family_label})>"
 
     def plot(self, ax: Axes) -> Axes:
         """Plot the family curves."""
@@ -265,18 +319,26 @@ class PsychroCurves:
         # Curves family labelling
         if self.curves and self.family_label is not None:
             style = self.curves[0].style or {}
-            ax.plot([-1], [-1], label=self.family_label,
-                    marker='D', markersize=10, **style)
+            ax.plot(
+                [-1],
+                [-1],
+                label=self.family_label,
+                marker="D",
+                markersize=10,
+                **style,
+            )
 
         return ax
 
 
 def _gen_list_curves_range_temps(
-        func_curve: Callable,
-        dbt_min: float, dbt_max: float, increment: float,
-        curves_values: list,
-        p_atm_kpa: float=PRESSURE_STD_ATM_KPA) -> Tuple[List[float],
-                                                        List[List[float]]]:
+    func_curve: Callable,
+    dbt_min: float,
+    dbt_max: float,
+    increment: float,
+    curves_values: list,
+    p_atm_kpa: float = PRESSURE_STD_ATM_KPA,
+) -> Tuple[List[float], List[List[float]]]:
     """Generate a curve from a range of temperatures."""
     temps = f_range(dbt_min, dbt_max + increment, increment)
     curves = [func_curve(temps, value, p_atm_kpa) for value in curves_values]
@@ -284,64 +346,100 @@ def _gen_list_curves_range_temps(
 
 
 def curve_constant_humidity_ratio(
-        dry_temps: Iterable[float],
-        rh_percentage: Union[float, Iterable[float]]=100.,
-        p_atm_kpa: float=PRESSURE_STD_ATM_KPA, mode_sat=1) -> List[float]:
+    dry_temps: Iterable[float],
+    rh_percentage: Union[float, Iterable[float]] = 100.0,
+    p_atm_kpa: float = PRESSURE_STD_ATM_KPA,
+    mode_sat=1,
+) -> List[float]:
     """Generate a curve (numpy array) of constant humidity ratio."""
     if isinstance(rh_percentage, Iterable):
-        return [1000 * humidity_ratio(
+        return [
+            1000
+            * humidity_ratio(
+                saturation_pressure_water_vapor(t, mode=mode_sat) * rh / 100.0,
+                p_atm_kpa,
+            )
+            for t, rh in zip(dry_temps, rh_percentage)
+        ]
+    return [
+        1000
+        * humidity_ratio(
             saturation_pressure_water_vapor(t, mode=mode_sat)
-            * rh / 100., p_atm_kpa)
-                for t, rh in zip(dry_temps, rh_percentage)]
-    return [1000 * humidity_ratio(
-        saturation_pressure_water_vapor(t, mode=mode_sat)
-        * rh_percentage / 100., p_atm_kpa)
-            for t in dry_temps]
+            * rh_percentage
+            / 100.0,
+            p_atm_kpa,
+        )
+        for t in dry_temps
+    ]
 
 
 def _make_zone_dbt_rh(
-        t_min: float, t_max: float, increment: float,
-        rh_min: float, rh_max: float,
-        p_atm_kpa: float=PRESSURE_STD_ATM_KPA,
-        style: dict=None,
-        label: str=None,
-        logger=None) -> PsychroCurve:
+    t_min: float,
+    t_max: float,
+    increment: float,
+    rh_min: float,
+    rh_max: float,
+    p_atm_kpa: float = PRESSURE_STD_ATM_KPA,
+    style: dict = None,
+    label: str = None,
+    logger=None,
+) -> PsychroCurve:
     """Generate points for zone between constant dry bulb temps and RH."""
     temps = f_range(t_min, t_max + increment, increment)
     curve_rh_up = curve_constant_humidity_ratio(temps, rh_max, p_atm_kpa)
     curve_rh_down = curve_constant_humidity_ratio(temps, rh_min, p_atm_kpa)
-    abs_humid = (curve_rh_up + curve_rh_down[::-1]
-                 + [curve_rh_up[0]])  # type: List[float]
-    temps_zone = temps + temps[::-1] + [temps[0]]  # type: List[float]
-    return PsychroCurve(temps_zone, abs_humid, style,
-                        type_curve='constant_rh_data', label=label,
-                        logger=logger)
+    abs_humid: List[float] = (
+        curve_rh_up + curve_rh_down[::-1] + [curve_rh_up[0]]
+    )
+    temps_zone: List[float] = temps + temps[::-1] + [temps[0]]
+    return PsychroCurve(
+        temps_zone,
+        abs_humid,
+        style,
+        type_curve="constant_rh_data",
+        label=label,
+        logger=logger,
+    )
 
 
 def _valid_zone_type(zone_type: str) -> bool:
     """Implemented zone types."""
-    if zone_type in ['dbt-rh', 'xy-points']:
+    if zone_type in ("dbt-rh", "xy-points"):
         return True
     return False
 
 
 def _make_zone(
-        zone_conf: Dict, increment: float,
-        p_atm_kpa: float=PRESSURE_STD_ATM_KPA,
-        logger=None) -> PsychroCurve:
+    zone_conf: Dict,
+    increment: float,
+    p_atm_kpa: float = PRESSURE_STD_ATM_KPA,
+    logger=None,
+) -> PsychroCurve:
     """Generate points for zone between constant dry bulb temps and RH."""
-    if zone_conf['zone_type'] == 'dbt-rh':
-        t_min, t_max = zone_conf['points_x']
-        rh_min, rh_max = zone_conf['points_y']
+    if zone_conf["zone_type"] == "dbt-rh":
+        t_min, t_max = zone_conf["points_x"]
+        rh_min, rh_max = zone_conf["points_y"]
         return _make_zone_dbt_rh(
-            t_min, t_max, increment, rh_min, rh_max, p_atm_kpa,
-            zone_conf['style'], label=zone_conf.get('label'), logger=logger)
+            t_min,
+            t_max,
+            increment,
+            rh_min,
+            rh_max,
+            p_atm_kpa,
+            zone_conf["style"],
+            label=zone_conf.get("label"),
+            logger=logger,
+        )
     # elif zone_conf['zone_type'] == 'xy-points':
     else:
         return PsychroCurve(
-            zone_conf['points_x'], zone_conf['points_y'], zone_conf['style'],
-            type_curve='custom path', label=zone_conf.get('label'),
-            logger=logger)
+            zone_conf["points_x"],
+            zone_conf["points_y"],
+            zone_conf["style"],
+            type_curve="custom path",
+            label=zone_conf.get("label"),
+            logger=logger,
+        )
     # elif zone_conf['zone_type'] == 'dbt-rh-points':
     # make conversion rh -> w
 
@@ -349,43 +447,47 @@ def _make_zone(
 class PsychroChart:
     """Psychrometric chart object handler."""
 
-    def __init__(self,
-                 styles: Union[dict, str]=None,
-                 zones_file: Union[dict, str]=None,
-                 logger: Any=None,
-                 verbose: bool=False) -> None:
+    def __init__(
+        self,
+        styles: Union[dict, str] = None,
+        zones_file: Union[dict, str] = None,
+        logger: Any = None,
+        verbose: bool = False,
+    ) -> None:
         """Create the PsychroChart object."""
         self._logger = logger
         self._verbose = verbose
-        self.d_config = {}  # type: dict
-        self.figure_params = {}  # type: dict
+        self.d_config: dict = {}
+        self.figure_params: dict = {}
         self.dbt_min = self.dbt_max = -100
         self.w_min = self.w_max = -1
-        self.temp_step = 1.
+        self.temp_step = 1.0
         self.altitude_m = -1
-        self.chart_params = {}  # type: dict
+        self.chart_params: dict = {}
         self.p_atm_kpa = PRESSURE_STD_ATM_KPA
-        self.constant_dry_temp_data = None  # type: Optional[PsychroCurves]
-        self.constant_humidity_data = None  # type: Optional[PsychroCurves]
-        self.constant_rh_data = None  # type: Optional[PsychroCurves]
-        self.constant_h_data = None  # type: Optional[PsychroCurves]
-        self.constant_v_data = None  # type: Optional[PsychroCurves]
-        self.constant_wbt_data = None  # type: Optional[PsychroCurves]
-        self.saturation = None  # type: Optional[PsychroCurves]
-        self.zones = []  # type: List
+        self.constant_dry_temp_data: Optional[PsychroCurves] = None
+        self.constant_humidity_data: Optional[PsychroCurves] = None
+        self.constant_rh_data: Optional[PsychroCurves] = None
+        self.constant_h_data: Optional[PsychroCurves] = None
+        self.constant_v_data: Optional[PsychroCurves] = None
+        self.constant_wbt_data: Optional[PsychroCurves] = None
+        self.saturation: Optional[PsychroCurves] = None
+        self.zones: List = []
 
-        self._fig = None  # type: figure.Figure
-        self._canvas = None  # type: FigureCanvas
-        self._axes = None  # type: Axes
-        self._legend = None  # type: Legend
-        self._handlers_annotations = []  # type: List
+        self._fig: Optional[figure.Figure] = None
+        self._canvas: Optional[FigureCanvas] = None
+        self._axes: Optional[Axes] = None
+        self._legend: Optional[Legend] = None
+        self._handlers_annotations: List = []
 
         self._make_chart_data(styles, zones_file)
 
     def __repr__(self) -> str:
         """Return a string representation of the PsychroChart object."""
-        return '<PsychroChart [{:g}->{:g} °C, {:g}->{:g} gr/kg_da]>'.format(
-            self.dbt_min, self.dbt_max, self.w_min, self.w_max)
+        return (
+            f"<PsychroChart [{self.dbt_min:g}->{self.dbt_max:g} °C, "
+            f"{self.w_min:g}->{self.w_max:g} gr/kg_da]>"
+        )
 
     @property
     def axes(self) -> Axes:
@@ -395,84 +497,122 @@ class PsychroChart:
         assert isinstance(self._axes, Axes)
         return self._axes
 
-    def _make_chart_data(self,
-                         styles: Union[dict, str]=None,
-                         zones_file: Union[dict, str]=None) -> None:
+    def _make_chart_data(
+        self,
+        styles: Union[dict, str] = None,
+        zones_file: Union[dict, str] = None,
+    ) -> None:
         """Generate the data to plot the psychrometric chart."""
         # Get styling
         config = load_config(styles)
         self.d_config = config
-        self.temp_step = config['limits']['step_temp']
+        self.temp_step = config["limits"]["step_temp"]
 
-        self.figure_params = config['figure']
-        self.dbt_min, self.dbt_max = config['limits']['range_temp_c']
-        self.w_min, self.w_max = config['limits']['range_humidity_g_kg']
-        self.chart_params = config['chart_params']
+        self.figure_params = config["figure"]
+        self.dbt_min, self.dbt_max = config["limits"]["range_temp_c"]
+        self.w_min, self.w_max = config["limits"]["range_humidity_g_kg"]
+        self.chart_params = config["chart_params"]
 
         # Base pressure
-        if config['limits'].get('pressure_kpa') is not None:
-            self.p_atm_kpa = config['limits']['pressure_kpa']
-        elif config['limits'].get('altitude_m') is not None:
-            self.altitude_m = config['limits']['altitude_m']
+        if config["limits"].get("pressure_kpa") is not None:
+            self.p_atm_kpa = config["limits"]["pressure_kpa"]
+        elif config["limits"].get("altitude_m") is not None:
+            self.altitude_m = config["limits"]["altitude_m"]
             self.p_atm_kpa = pressure_by_altitude(self.altitude_m)
 
         # Dry bulb constant lines (vertical):
         if self.chart_params["with_constant_dry_temp"]:
             step = self.chart_params["constant_temp_step"]
-            style = config['constant_dry_temp']
+            style = config["constant_dry_temp"]
             temps_vl = f_range(self.dbt_min, self.dbt_max, step)
-            heights = [1000 * humidity_ratio(
-                saturation_pressure_water_vapor(t),
-                p_atm_kpa=self.p_atm_kpa) for t in temps_vl]
+            heights = [
+                1000
+                * humidity_ratio(
+                    saturation_pressure_water_vapor(t),
+                    p_atm_kpa=self.p_atm_kpa,
+                )
+                for t in temps_vl
+            ]
 
             self.constant_dry_temp_data = PsychroCurves(
-                [PsychroCurve([t, t], [self.w_min, h], style,
-                              type_curve='constant_dry_temp_data',
-                              label=None, logger=self._logger)
-                 for t, h in zip(temps_vl, heights)],
-                family_label=self.chart_params["constant_temp_label"])
+                [
+                    PsychroCurve(
+                        [t, t],
+                        [self.w_min, h],
+                        style,
+                        type_curve="constant_dry_temp_data",
+                        logger=self._logger,
+                    )
+                    for t, h in zip(temps_vl, heights)
+                ],
+                family_label=self.chart_params["constant_temp_label"],
+            )
 
         # Absolute humidity constant lines (horizontal):
         if self.chart_params["with_constant_humidity"]:
             step = self.chart_params["constant_humid_step"]
-            style = config['constant_humidity']
+            style = config["constant_humidity"]
             ws_hl = f_range(self.w_min + step, self.w_max + step / 10, step)
             dew_points = solve_curves_with_iteration(
-                'DEW POINT', [x / 1000 for x in ws_hl],
+                "DEW POINT",
+                [x / 1000 for x in ws_hl],
                 lambda x: dew_point_temperature(
-                        water_vapor_pressure(
-                            x, p_atm_kpa=self.p_atm_kpa)),
+                    water_vapor_pressure(x, p_atm_kpa=self.p_atm_kpa)
+                ),
                 lambda x: humidity_ratio(
                     saturation_pressure_water_vapor(x),
-                    p_atm_kpa=self.p_atm_kpa))
+                    p_atm_kpa=self.p_atm_kpa,
+                ),
+            )
 
             self.constant_humidity_data = PsychroCurves(
-                [PsychroCurve([t_dp, self.dbt_max], [w, w], style,
-                              type_curve='constant_humidity_data',
-                              label=None, logger=self._logger)
-                 for w, t_dp in zip(ws_hl, dew_points)],
-                family_label=self.chart_params["constant_humid_label"])
+                [
+                    PsychroCurve(
+                        [t_dp, self.dbt_max],
+                        [w, w],
+                        style,
+                        type_curve="constant_humidity_data",
+                        logger=self._logger,
+                    )
+                    for w, t_dp in zip(ws_hl, dew_points)
+                ],
+                family_label=self.chart_params["constant_humid_label"],
+            )
 
         # Constant relative humidity curves:
         if self.chart_params["with_constant_rh"]:
             rh_perc_values = self.chart_params["constant_rh_curves"]
             rh_label_values = self.chart_params.get("constant_rh_labels", [])
-            label_loc = self.chart_params.get("constant_rh_labels_loc", .85)
+            label_loc = self.chart_params.get("constant_rh_labels_loc", 0.85)
             style = config["constant_rh"]
             temps_ct_rh, curves_ct_rh = _gen_list_curves_range_temps(
                 curve_constant_humidity_ratio,
-                self.dbt_min, self.dbt_max, self.temp_step,
-                rh_perc_values, p_atm_kpa=self.p_atm_kpa)
+                self.dbt_min,
+                self.dbt_max,
+                self.temp_step,
+                rh_perc_values,
+                p_atm_kpa=self.p_atm_kpa,
+            )
 
             self.constant_rh_data = PsychroCurves(
-                [PsychroCurve(
-                    temps_ct_rh, curve_ct_rh, style,
-                    type_curve='constant_rh_data',
-                    label_loc=label_loc, label='RH {:g} %'.format(rh)
-                    if round(rh, 1) in rh_label_values else None,
-                    logger=self._logger)
-                    for rh, curve_ct_rh in zip(rh_perc_values, curves_ct_rh)],
-                family_label=self.chart_params["constant_rh_label"])
+                [
+                    PsychroCurve(
+                        temps_ct_rh,
+                        curve_ct_rh,
+                        style,
+                        type_curve="constant_rh_data",
+                        label_loc=label_loc,
+                        label=(
+                            f"RH {rh:g} %"
+                            if round(rh, 1) in rh_label_values
+                            else None
+                        ),
+                        logger=self._logger,
+                    )
+                    for rh, curve_ct_rh in zip(rh_perc_values, curves_ct_rh)
+                ],
+                family_label=self.chart_params["constant_rh_label"],
+            )
 
         # Constant enthalpy lines:
         if self.chart_params["with_constant_h"]:
@@ -480,33 +620,54 @@ class PsychroChart:
             start, end = self.chart_params["range_h"]
             enthalpy_values = f_range(start, end, step)
             h_label_values = self.chart_params.get("constant_h_labels", [])
-            label_loc = self.chart_params.get("constant_h_labels_loc", 1.)
+            label_loc = self.chart_params.get("constant_h_labels_loc", 1.0)
             style = config["constant_h"]
             temps_max_constant_h = [
-                dry_temperature_for_enthalpy_of_moist_air(
-                    self.w_min / 1000, h)
-                for h in enthalpy_values]
+                dry_temperature_for_enthalpy_of_moist_air(self.w_min / 1000, h)
+                for h in enthalpy_values
+            ]
 
             sat_points = solve_curves_with_iteration(
-                'ENTHALPHY', enthalpy_values,
+                "ENTHALPHY",
+                enthalpy_values,
                 lambda x: dry_temperature_for_enthalpy_of_moist_air(
-                    self.w_min / 1000 + 0.1, x),
+                    self.w_min / 1000 + 0.1, x
+                ),
                 lambda x: enthalpy_moist_air(
-                    x, saturation_pressure_water_vapor(x),
-                    p_atm_kpa=self.p_atm_kpa))
+                    x,
+                    saturation_pressure_water_vapor(x),
+                    p_atm_kpa=self.p_atm_kpa,
+                ),
+            )
 
             self.constant_h_data = PsychroCurves(
-                [PsychroCurve(
-                    [t_sat, t_max], [1000 * humidity_ratio(
-                        saturation_pressure_water_vapor(t_sat),
-                        self.p_atm_kpa), self.w_min], style,
-                    type_curve='constant_h_data',
-                    label_loc=label_loc, label='{:g} kJ/kg_da'.format(h)
-                    if round(h, 3) in h_label_values else None,
-                    logger=self._logger)
+                [
+                    PsychroCurve(
+                        [t_sat, t_max],
+                        [
+                            1000
+                            * humidity_ratio(
+                                saturation_pressure_water_vapor(t_sat),
+                                self.p_atm_kpa,
+                            ),
+                            self.w_min,
+                        ],
+                        style,
+                        type_curve="constant_h_data",
+                        label_loc=label_loc,
+                        label=(
+                            f"{h:g} kJ/kg_da"
+                            if round(h, 3) in h_label_values
+                            else None
+                        ),
+                        logger=self._logger,
+                    )
                     for t_sat, t_max, h in zip(
-                    sat_points, temps_max_constant_h, enthalpy_values)],
-                family_label=self.chart_params["constant_h_label"])
+                        sat_points, temps_max_constant_h, enthalpy_values
+                    )
+                ],
+                family_label=self.chart_params["constant_h_label"],
+            )
 
         # Constant specific volume lines:
         if self.chart_params["with_constant_v"]:
@@ -514,32 +675,55 @@ class PsychroChart:
             start, end = self.chart_params["range_vol_m3_kg"]
             vol_values = f_range(start, end, step)
             vol_label_values = self.chart_params.get("constant_v_labels", [])
-            label_loc = self.chart_params.get("constant_v_labels_loc", 1.)
+            label_loc = self.chart_params.get("constant_v_labels_loc", 1.0)
             style = config["constant_v"]
             temps_max_constant_v = [
                 dry_temperature_for_specific_volume_of_moist_air(
-                    0, specific_vol, p_atm_kpa=self.p_atm_kpa)
-                for specific_vol in vol_values]
+                    0, specific_vol, p_atm_kpa=self.p_atm_kpa
+                )
+                for specific_vol in vol_values
+            ]
             sat_points = solve_curves_with_iteration(
-                'CONSTANT VOLUME', vol_values,
+                "CONSTANT VOLUME",
+                vol_values,
                 lambda x: dry_temperature_for_specific_volume_of_moist_air(
-                    0, x, p_atm_kpa=self.p_atm_kpa),
+                    0, x, p_atm_kpa=self.p_atm_kpa
+                ),
                 lambda x: specific_volume(
-                    x, saturation_pressure_water_vapor(x),
-                    p_atm_kpa=self.p_atm_kpa))
+                    x,
+                    saturation_pressure_water_vapor(x),
+                    p_atm_kpa=self.p_atm_kpa,
+                ),
+            )
 
             self.constant_v_data = PsychroCurves(
-                [PsychroCurve(
-                    [t_sat, t_max], [1000 * humidity_ratio(
-                        saturation_pressure_water_vapor(t_sat),
-                        self.p_atm_kpa), 0],
-                    style, type_curve='constant_v_data',
-                    label_loc=label_loc, label='{:g} m3/kg_da'.format(vol)
-                    if round(vol, 3) in vol_label_values else None,
-                    logger=self._logger)
+                [
+                    PsychroCurve(
+                        [t_sat, t_max],
+                        [
+                            1000
+                            * humidity_ratio(
+                                saturation_pressure_water_vapor(t_sat),
+                                self.p_atm_kpa,
+                            ),
+                            0,
+                        ],
+                        style,
+                        type_curve="constant_v_data",
+                        label_loc=label_loc,
+                        label=(
+                            f"{vol:g} m3/kg_da"
+                            if round(vol, 3) in vol_label_values
+                            else None
+                        ),
+                        logger=self._logger,
+                    )
                     for t_sat, t_max, vol in zip(
-                    sat_points, temps_max_constant_v, vol_values)],
-                family_label=self.chart_params["constant_v_label"])
+                        sat_points, temps_max_constant_v, vol_values
+                    )
+                ],
+                family_label=self.chart_params["constant_v_label"],
+            )
 
         # Constant wet bulb temperature lines:
         if self.chart_params["with_constant_wet_temp"]:
@@ -547,47 +731,76 @@ class PsychroChart:
             start, end = self.chart_params["range_wet_temp"]
             wbt_values = f_range(start, end, step)
             wbt_label_values = self.chart_params.get(
-                "constant_wet_temp_labels", [])
+                "constant_wet_temp_labels", []
+            )
             label_loc = self.chart_params.get(
-                "constant_wet_temp_labels_loc", .05)
+                "constant_wet_temp_labels_loc", 0.05
+            )
             style = config["constant_wet_temp"]
-            w_max_constant_wbt = [humidity_ratio(
-                saturation_pressure_water_vapor(wbt), self.p_atm_kpa)
-                for wbt in wbt_values]
+            w_max_constant_wbt = [
+                humidity_ratio(
+                    saturation_pressure_water_vapor(wbt), self.p_atm_kpa
+                )
+                for wbt in wbt_values
+            ]
 
             self.constant_wbt_data = PsychroCurves(
-                [PsychroCurve(
-                    [wbt, self.dbt_max],
-                    [1000 * w_max,
-                     1000 * humidity_ratio(
-                         saturation_pressure_water_vapor(self.dbt_max)
-                         * relative_humidity_from_temps(
-                             self.dbt_max, wbt, p_atm_kpa=self.p_atm_kpa),
-                         p_atm_kpa=self.p_atm_kpa)], style,
-                    type_curve='constant_wbt_data',
-                    label_loc=label_loc, label='{:g} °C'.format(wbt)
-                    if wbt in wbt_label_values else None, logger=self._logger)
-                    for wbt, w_max in zip(wbt_values, w_max_constant_wbt)],
-                family_label=self.chart_params["constant_wet_temp_label"])
+                [
+                    PsychroCurve(
+                        [wbt, self.dbt_max],
+                        [
+                            1000 * w_max,
+                            1000
+                            * humidity_ratio(
+                                saturation_pressure_water_vapor(self.dbt_max)
+                                * relative_humidity_from_temps(
+                                    self.dbt_max, wbt, p_atm_kpa=self.p_atm_kpa
+                                ),
+                                p_atm_kpa=self.p_atm_kpa,
+                            ),
+                        ],
+                        style,
+                        type_curve="constant_wbt_data",
+                        label_loc=label_loc,
+                        label=(
+                            f"{wbt:g} °C" if wbt in wbt_label_values else None
+                        ),
+                        logger=self._logger,
+                    )
+                    for wbt, w_max in zip(wbt_values, w_max_constant_wbt)
+                ],
+                family_label=self.chart_params["constant_wet_temp_label"],
+            )
 
         # Saturation line:
         if True:
             sat_style = config["saturation"]
             temps_sat_line, w_sat_line = _gen_list_curves_range_temps(
                 curve_constant_humidity_ratio,
-                self.dbt_min, self.dbt_max, self.temp_step, [100],
-                p_atm_kpa=self.p_atm_kpa)
+                self.dbt_min,
+                self.dbt_max,
+                self.temp_step,
+                [100],
+                p_atm_kpa=self.p_atm_kpa,
+            )
 
             self.saturation = PsychroCurves(
-                [PsychroCurve(
-                    temps_sat_line, w_sat_line[0], sat_style,
-                    type_curve='saturation', logger=self._logger)])
+                [
+                    PsychroCurve(
+                        temps_sat_line,
+                        w_sat_line[0],
+                        sat_style,
+                        type_curve="saturation",
+                        logger=self._logger,
+                    )
+                ]
+            )
 
         # Zones
         if self.chart_params["with_zones"] or zones_file is not None:
             self.append_zones(zones_file)
 
-    def append_zones(self, zones: Union[dict, str]=None) -> None:
+    def append_zones(self, zones: Union[dict, str] = None) -> None:
         """Append zones as patches to the psychrometric chart."""
         if zones is None:
             # load default 'Comfort' zones (Spain RITE)
@@ -595,18 +808,23 @@ class PsychroChart:
         else:
             d_zones = load_zones(zones)
 
-        zones_ok = [_make_zone(
-            zone_conf, self.temp_step, self.p_atm_kpa, logger=self._logger)
-            for zone_conf in d_zones['zones']
-            if _valid_zone_type(zone_conf['zone_type'])]
+        zones_ok = [
+            _make_zone(
+                zone_conf, self.temp_step, self.p_atm_kpa, logger=self._logger
+            )
+            for zone_conf in d_zones["zones"]
+            if _valid_zone_type(zone_conf["zone_type"])
+        ]
         if zones_ok:
             self.zones.append(PsychroCurves(zones_ok))
 
-    def plot_points_dbt_rh(self,
-                           points: Dict,
-                           connectors: list=None,
-                           convex_groups: list=None,
-                           scatter_style: dict=None) -> Dict:
+    def plot_points_dbt_rh(
+        self,
+        points: Dict,
+        connectors: list = None,
+        convex_groups: list = None,
+        scatter_style: dict = None,
+    ) -> Dict:
         """Append individual points, connectors and groups to the plot.
 
         * Pass a specific style dict to do a scatter plot:
@@ -673,8 +891,12 @@ class PsychroChart:
         ```
         """
         use_scatter, points_plot = False, {}
-        default_style = {'marker': 'o', 'markersize': 10,
-                         'color': [1, .8, 0.1, .8], 'linewidth': 0}
+        default_style = {
+            "marker": "o",
+            "markersize": 10,
+            "color": [1, 0.8, 0.1, 0.8],
+            "linewidth": 0,
+        }
         if scatter_style is not None:
             default_style = scatter_style
             use_scatter = True
@@ -682,56 +904,78 @@ class PsychroChart:
         for key, point in points.items():
             plot_params = default_style.copy()
             if isinstance(point, dict):
-                plot_params.update(point.get('style', {}))
-                plot_params['label'] = point.get('label')
-                point = point['xy']
+                plot_params.update(point.get("style", {}))
+                plot_params["label"] = point.get("label")
+                point = point["xy"]
             temp = point[0]
             if isinstance(temp, Iterable):
                 w_g_ka = curve_constant_humidity_ratio(
-                    temp, rh_percentage=point[1], p_atm_kpa=self.p_atm_kpa)
+                    temp, rh_percentage=point[1], p_atm_kpa=self.p_atm_kpa
+                )
                 points_plot[key] = temp, w_g_ka, plot_params
             else:
                 w_g_ka = curve_constant_humidity_ratio(
-                    [temp], rh_percentage=point[1],
-                    p_atm_kpa=self.p_atm_kpa)[0]
+                    [temp], rh_percentage=point[1], p_atm_kpa=self.p_atm_kpa
+                )[0]
                 points_plot[key] = [temp], [w_g_ka], plot_params
 
         if connectors is not None:
-            for i, d_con in enumerate(connectors):
-                if (d_con['start'] in points_plot and
-                        d_con['end'] in points_plot):
-                    x_start = points_plot[d_con['start']][0][0]
-                    y_start = points_plot[d_con['start']][1][0]
-                    x_end = points_plot[d_con['end']][0][0]
-                    y_end = points_plot[d_con['end']][1][0]
+            for d_con in connectors:
+                if (
+                    d_con["start"] in points_plot
+                    and d_con["end"] in points_plot
+                ):
+                    x_start = points_plot[d_con["start"]][0][0]
+                    y_start = points_plot[d_con["start"]][1][0]
+                    x_end = points_plot[d_con["end"]][0][0]
+                    y_end = points_plot[d_con["end"]][1][0]
                     x_line = [x_start, x_end]
                     y_line = [y_start, y_end]
-                    style = d_con.get('style', points_plot[d_con['start']][2])
-                    line_label = d_con.get('label')
+                    style = d_con.get("style", points_plot[d_con["start"]][2])
+                    line_label = d_con.get("label")
                     self._handlers_annotations.append(
                         self.axes.plot(
-                            x_line, y_line, label = line_label,dash_capstyle='round', **style))
+                            x_line,
+                            y_line,
+                            label=line_label,
+                            dash_capstyle="round",
+                            **style,
+                        )
+                    )
                     self._handlers_annotations.append(
                         self.axes.plot(
-                            x_line, y_line,
-                            color=list(style['color'][:3]) + [.15],
-                            lw=50, solid_capstyle='round'))
+                            x_line,
+                            y_line,
+                            color=list(style["color"][:3]) + [0.15],
+                            lw=50,
+                            solid_capstyle="round",
+                        )
+                    )
 
         for point in points_plot.values():
             func_append = self.axes.scatter if use_scatter else self.axes.plot
             self._handlers_annotations.append(
-                func_append(point[0], point[1], **point[2]))
+                func_append(point[0], point[1], **point[2])
+            )
 
-        if (ConvexHull is not None
-                and convex_groups and points_plot and
-                (isinstance(convex_groups[0], list) or
-                 isinstance(convex_groups[0], tuple))
-                and len(convex_groups[0]) == 3):
+        if (
+            ConvexHull is not None
+            and convex_groups
+            and points_plot
+            and (
+                isinstance(convex_groups[0], list)
+                or isinstance(convex_groups[0], tuple)
+            )
+            and len(convex_groups[0]) == 3
+        ):
             for convex_hull_zone, style_line, style_fill in convex_groups:
                 int_points = np.array(
-                    [(point[0][0], point[1][0])
-                     for name, point in points_plot.items()
-                     if name in convex_hull_zone])
+                    [
+                        (point[0][0], point[1][0])
+                        for name, point in points_plot.items()
+                        if name in convex_hull_zone
+                    ]
+                )
 
                 if len(int_points) < 3:
                     continue
@@ -739,17 +983,25 @@ class PsychroChart:
                 try:
                     hull = ConvexHull(int_points)
                 except QhullError:  # pragma: no cover
-                    self._print_err('QhullError with points: %s', int_points)
+                    self._print_err("QhullError with points: %s", int_points)
                     continue
 
                 # noinspection PyUnresolvedReferences
                 for simplex in hull.simplices:
                     self._handlers_annotations.append(
-                        self.axes.plot(int_points[simplex, 0],
-                                       int_points[simplex, 1], **style_line))
+                        self.axes.plot(
+                            int_points[simplex, 0],
+                            int_points[simplex, 1],
+                            **style_line,
+                        )
+                    )
                 self._handlers_annotations.append(
-                    self.axes.fill(int_points[hull.vertices, 0],
-                                   int_points[hull.vertices, 1], **style_fill))
+                    self.axes.fill(
+                        int_points[hull.vertices, 0],
+                        int_points[hull.vertices, 1],
+                        **style_fill,
+                    )
+                )
 
         return points_plot
 
@@ -758,93 +1010,91 @@ class PsychroChart:
         points_plot = {}
         default_style = {
             "linewidth": 0,
-            "color": [1, .8, 0.1, .8],
-            "arrowstyle": 'wedge'}
+            "color": [1, 0.8, 0.1, 0.8],
+            "arrowstyle": "wedge",
+        }
         for key, pair_point in points_pairs.items():
             plot_params = default_style.copy()
             if isinstance(pair_point, dict):
-                if 'style' in pair_point and "color" in pair_point['style']:
-                    plot_params['color'] = mod_color(
-                        pair_point['style']['color'], .6)  # set alpha
-                point1, point2 = pair_point['xy']
+                if "style" in pair_point and "color" in pair_point["style"]:
+                    plot_params["color"] = mod_color(
+                        pair_point["style"]["color"], 0.6
+                    )  # set alpha
+                point1, point2 = pair_point["xy"]
             else:
                 point1, point2 = pair_point
             temp1 = point1[0]
             temp2 = point2[0]
             w_g_ka1 = curve_constant_humidity_ratio(
-                [temp1], rh_percentage=point1[1], p_atm_kpa=self.p_atm_kpa)[0]
+                [temp1], rh_percentage=point1[1], p_atm_kpa=self.p_atm_kpa
+            )[0]
             w_g_ka2 = curve_constant_humidity_ratio(
-                [temp2], rh_percentage=point2[1], p_atm_kpa=self.p_atm_kpa)[0]
+                [temp2], rh_percentage=point2[1], p_atm_kpa=self.p_atm_kpa
+            )[0]
 
             self._handlers_annotations.append(
                 self.axes.annotate(
-                    '', (temp2, w_g_ka2), xytext=(temp1, w_g_ka1),
-                    arrowprops=plot_params))
+                    "",
+                    (temp2, w_g_ka2),
+                    xytext=(temp1, w_g_ka1),
+                    arrowprops=plot_params,
+                )
+            )
 
             points_plot[key] = (temp1, w_g_ka1), (temp2, w_g_ka2), plot_params
 
         return points_plot
 
     def plot_vertical_dry_bulb_temp_line(
-            self, temp: float,
-            style: dict=None,
-            label: str=None,
-            reverse: bool=False,
-            **label_params) -> None:
+        self,
+        temp: float,
+        style: dict = None,
+        label: str = None,
+        reverse: bool = False,
+        **label_params,
+    ) -> None:
         """Append a vertical line from w_min to w_sat."""
         w_max = 1000 * humidity_ratio(
-            saturation_pressure_water_vapor(temp), self.p_atm_kpa)
+            saturation_pressure_water_vapor(temp), self.p_atm_kpa
+        )
 
         style_curve = style or self.d_config.get("constant_dry_temp")
         path_y = [w_max, self.w_min] if reverse else [self.w_min, w_max]
         curve = PsychroCurve(
-            [temp, temp], path_y, style=style_curve, logger=self._logger)
+            [temp, temp], path_y, style=style_curve, logger=self._logger
+        )
         curve.plot(self.axes)
         if label is not None:
             curve.add_label(self.axes, label, **label_params)
 
     def plot_legend(
-            self, loc: str='upper left', markerscale: float=.9,
-            frameon: bool=True, fancybox: bool=True,
-            edgecolor: Union[str, Iterable]='darkgrey', fontsize: float=15.,
-            labelspacing: float=1.5, **params) -> None:
+        self,
+        loc: str = "upper left",
+        markerscale: float = 0.9,
+        frameon: bool = True,
+        fancybox: bool = True,
+        edgecolor: Union[str, Iterable] = "darkgrey",
+        fontsize: float = 15.0,
+        labelspacing: float = 1.5,
+        **params,
+    ) -> None:
         """Append a legend to the psychrochart plot."""
         self._legend = self.axes.legend(
-            loc=loc, markerscale=markerscale, frameon=frameon,
-            edgecolor=edgecolor, fontsize=fontsize, fancybox=fancybox,
-            labelspacing=labelspacing, **params)
+            loc=loc,
+            markerscale=markerscale,
+            frameon=frameon,
+            edgecolor=edgecolor,
+            fontsize=fontsize,
+            fancybox=fancybox,
+            labelspacing=labelspacing,
+            **params,
+        )
 
-    def plot(self, ax: Axes=None) -> Axes:
-        """Plot the psychrochart and return the matplotlib Axes instance."""
-        def _apply_spines_style(axes, style, location='right'):
-            for key in style:
-                if (key == 'color') or (key == 'c'):
-                    axes.spines[location].set_color(style[key])
-                elif (key == 'linewidth') or (key == 'lw'):
-                    axes.spines[location].set_linewidth(style[key])
-                elif (key == 'linestyle') or (key == 'ls'):
-                    axes.spines[location].set_linestyle(style[key])
-                else:  # pragma: no cover
-                    try:
-                        getattr(axes.spines[location],
-                                'set_{}'.format(key))(style[key])
-                    except Exception as exc:
-                        self._print_err(
-                            "Error trying to apply spines attrs: %s. (%s)",
-                            exc, dir(axes.spines[location]))
-
-        # Prepare fig & axis
+    def _prepare_fig_and_axis(self, ax: Axes = None) -> Tuple[Axes, dict]:
+        """Prepare matplotlib fig & Axes object for the chart."""
         fig_params = self.figure_params.copy()
-        figsize = fig_params.pop('figsize', (16, 9))
-        position = fig_params.pop('position', [0.025, 0.075, 0.925, 0.875])
-        fontsize = fig_params.pop('fontsize', 10)
-        x_style = fig_params.pop('x_axis', {})
-        x_style_labels = fig_params.pop('x_axis_labels', {})
-        x_style_ticks = fig_params.pop('x_axis_ticks', {})
-        y_style = fig_params.pop('y_axis', {})
-        y_style_labels = fig_params.pop('y_axis_labels', {})
-        y_style_ticks = fig_params.pop('y_axis_ticks', {})
-        partial_axis = fig_params.pop('partial_axis', True)
+        figsize = fig_params.pop("figsize", (16, 9))
+        position = fig_params.pop("position", [0.025, 0.075, 0.925, 0.875])
 
         # Create figure and format axis
         self._fig = figure.Figure(figsize=figsize, dpi=150, frameon=False)
@@ -855,72 +1105,132 @@ class PsychroChart:
         ax.yaxis.set_label_position("right")
         ax.set_xlim(self.dbt_min, self.dbt_max)
         ax.set_ylim(self.w_min, self.w_max)
-        ax.grid(False, which='major', axis='both')
-        ax.grid(False, which='minor', axis='both')
+        ax.grid(False)
+        ax.grid(False, which="minor")
 
-        # Apply axis styles
-        if fig_params['x_label'] is not None:
-            style_axis = x_style_labels.copy()
-            style_axis['fontsize'] *= 1.2
-            ax.set_xlabel(fig_params['x_label'], **style_axis)
-        if fig_params['y_label'] is not None:
-            style_axis = y_style_labels.copy()
-            style_axis['fontsize'] *= 1.2
-            ax.set_ylabel(fig_params['y_label'], **style_axis)
-        if fig_params['title'] is not None:
-            ax.set_title(fig_params['title'],
-                         fontsize=fontsize * 1.5, fontweight='bold')
+        return ax, fig_params
 
-        _apply_spines_style(ax, y_style, location='right')
-        _apply_spines_style(ax, x_style, location='bottom')
-        if partial_axis:  # Hide left and top axis
-            ax.spines['left'].set_visible(False)
-            ax.spines['top'].set_visible(False)
-        else:
-            _apply_spines_style(ax, y_style, location='left')
-            _apply_spines_style(ax, x_style, location='top')
-
-        if x_style_ticks:
-            ax.tick_params(axis='x', **x_style_ticks)
-        if y_style_ticks:
-            ax.tick_params(axis='y', **y_style_ticks)
-
+    def _set_tick_labels_in_main_axes(
+        self, ax: Axes, x_style_labels: dict, y_style_labels: dict
+    ):
+        """Plot the psychrochart and return the matplotlib Axes instance."""
         if self.chart_params.get("with_constant_dry_temp", True):
             step_label = self.chart_params.get(
-                "constant_temp_label_step", None)
+                "constant_temp_label_step", None
+            )
             if step_label:  # Explicit xticks
-                ticks = f_range(self.dbt_min, self.dbt_max + step_label / 10,
-                                step_label)
+                ticks = f_range(
+                    self.dbt_min, self.dbt_max + step_label / 10, step_label
+                )
                 if not self.chart_params.get(
-                        "constant_temp_label_include_limits", True):
-                    ticks = [t for t in ticks
-                             if t not in [self.dbt_min, self.dbt_max]]
+                    "constant_temp_label_include_limits", True
+                ):
+                    ticks = [
+                        t
+                        for t in ticks
+                        if t not in [self.dbt_min, self.dbt_max]
+                    ]
                 ax.set_xticks(ticks)
-                ax.set_xticklabels(
-                    ['{:g}'.format(t) for t in ticks], **x_style_labels)
+                ax.set_xticklabels([f"{t:g}" for t in ticks], **x_style_labels)
         else:
             ax.set_xticks([])
 
         if self.chart_params.get("with_constant_humidity", True):
             step_label = self.chart_params.get(
-                "constant_humid_label_step", None)
+                "constant_humid_label_step", None
+            )
             if step_label:  # Explicit xticks
-                ticks = f_range(self.w_min, self.w_max + step_label / 10,
-                                step_label)
+                ticks = f_range(
+                    self.w_min, self.w_max + step_label / 10, step_label
+                )
                 if not self.chart_params.get(
-                        "constant_humid_label_include_limits", True):
-                    ticks = [t for t in ticks
-                             if t not in [self.w_min, self.w_max]]
+                    "constant_humid_label_include_limits", True
+                ):
+                    ticks = [
+                        t for t in ticks if t not in [self.w_min, self.w_max]
+                    ]
                 ax.set_yticks(ticks)
-                ax.set_yticklabels(
-                    ['{:g}'.format(t) for t in ticks], **y_style_labels)
+                ax.set_yticklabels([f"{t:g}" for t in ticks], **y_style_labels)
         else:
             ax.set_yticks([])
 
+    def _apply_axis_styling(self, ax: Axes, fig_params: dict):
+        """Plot the psychrochart and return the matplotlib Axes instance."""
+
+        def _apply_spines_style(axes, style, location="right"):
+            for key in style:
+                if (key == "color") or (key == "c"):
+                    axes.spines[location].set_color(style[key])
+                elif (key == "linewidth") or (key == "lw"):
+                    axes.spines[location].set_linewidth(style[key])
+                elif (key == "linestyle") or (key == "ls"):
+                    axes.spines[location].set_linestyle(style[key])
+                else:  # pragma: no cover
+                    try:
+                        getattr(axes.spines[location], f"set_{key}")(
+                            style[key]
+                        )
+                    except Exception as exc:
+                        self._print_err(
+                            "Error trying to apply spines attrs: %s. (%s)",
+                            exc,
+                            dir(axes.spines[location]),
+                        )
+
+        # Get parameters to style axes
+        fontsize = fig_params.pop("fontsize", 10)
+        x_style = fig_params.pop("x_axis", {})
+        x_style_labels = fig_params.pop("x_axis_labels", {})
+        x_style_ticks = fig_params.pop("x_axis_ticks", {})
+        y_style = fig_params.pop("y_axis", {})
+        y_style_labels = fig_params.pop("y_axis_labels", {})
+        y_style_ticks = fig_params.pop("y_axis_ticks", {})
+        partial_axis = fig_params.pop("partial_axis", True)
+
+        # Apply axis styles
+        if fig_params["x_label"] is not None:
+            style_axis = x_style_labels.copy()
+            style_axis["fontsize"] *= 1.2
+            ax.set_xlabel(fig_params["x_label"], **style_axis)
+        if fig_params["y_label"] is not None:
+            style_axis = y_style_labels.copy()
+            style_axis["fontsize"] *= 1.2
+            ax.set_ylabel(fig_params["y_label"], **style_axis)
+        if fig_params["title"] is not None:
+            ax.set_title(
+                fig_params["title"], fontsize=fontsize * 1.5, fontweight="bold"
+            )
+
+        _apply_spines_style(ax, y_style, location="right")
+        _apply_spines_style(ax, x_style, location="bottom")
+        if partial_axis:  # Hide left and top axis
+            ax.spines["left"].set_visible(False)
+            ax.spines["top"].set_visible(False)
+        else:
+            _apply_spines_style(ax, y_style, location="left")
+            _apply_spines_style(ax, x_style, location="top")
+
+        if x_style_ticks:
+            ax.tick_params(axis="x", **x_style_ticks)
+        if y_style_ticks:
+            ax.tick_params(axis="y", **y_style_ticks)
+
+        self._set_tick_labels_in_main_axes(ax, x_style_labels, y_style_labels)
+
+    def plot(self, ax: Axes = None) -> Axes:
+        """Plot the psychrochart and return the matplotlib Axes instance."""
+        # Prepare fig & axis
+        ax, fig_params = self._prepare_fig_and_axis(ax)
+
+        # Apply axis styles
+        self._apply_axis_styling(ax, fig_params)
+
         # Plot curves:
-        [getattr(self, curve_family).plot(ax)
-         for curve_family in PSYCHRO_CURVES_KEYS
-         if getattr(self, curve_family) is not None]
+        [
+            getattr(self, curve_family).plot(ax)
+            for curve_family in PSYCHRO_CURVES_KEYS
+            if getattr(self, curve_family) is not None
+        ]
 
         # Plot zones:
         [zone.plot(ax=ax) for zone in self.zones]

--- a/psychrochart/chart.py
+++ b/psychrochart/chart.py
@@ -11,7 +11,6 @@ from typing import (
     Iterable,
     List,
     Optional,
-    Sequence,
     Tuple,
     Union,
 )
@@ -347,12 +346,12 @@ def _gen_list_curves_range_temps(
 
 
 def _curve_constant_humidity_ratio(
-    dry_temps: Sequence[float],
-    rh_percentage: Union[float, Sequence[float]],
+    dry_temps: List[float],
+    rh_percentage: Union[float, List[float]],
     p_atm_kpa: float,
 ) -> List[float]:
     """Generate a curve (numpy array) of constant humidity ratio."""
-    if isinstance(rh_percentage, Sequence):
+    if isinstance(rh_percentage, list):
         return [
             1000.0
             * humidity_ratio(
@@ -551,7 +550,7 @@ class PsychroChart:
                 "DEW POINT",
                 [x / 1000.0 for x in ws_hl],
                 lambda x: dew_point_temperature(
-                    self.dbt_max, water_vapor_pressure(x, self.p_atm_kpa)
+                    water_vapor_pressure(x, self.p_atm_kpa)
                 ),
                 lambda x: humidity_ratio(
                     saturation_pressure_water_vapor(x),
@@ -624,7 +623,7 @@ class PsychroChart:
                 "ENTHALPHY",
                 enthalpy_values,
                 lambda x: dry_temperature_for_enthalpy_of_moist_air(
-                    self.w_min / 1000.0, x
+                    self.w_min / 1000 + 0.1, x
                 ),
                 lambda x: enthalpy_moist_air(
                     x,
@@ -884,7 +883,7 @@ class PsychroChart:
         ```
         """
         use_scatter = False
-        points_plot: Dict[str, Tuple[Sequence, Sequence, dict]] = {}
+        points_plot: Dict[str, Tuple[List[float], List[float], dict]] = {}
         default_style = {
             "marker": "o",
             "markersize": 10,
@@ -902,14 +901,14 @@ class PsychroChart:
                 plot_params["label"] = point.get("label")
                 point = point["xy"]
             temp = point[0]
-            if isinstance(temp, Sequence):
+            if isinstance(temp, list):
                 w_g_ka = _curve_constant_humidity_ratio(
                     temp, point[1], self.p_atm_kpa
                 )
                 points_plot[key] = temp, w_g_ka, plot_params
             else:
                 w_g_ka = _curve_constant_humidity_ratio(
-                    [temp], point[1], self.p_atm_kpa
+                    [temp], rh_percentage=point[1], p_atm_kpa=self.p_atm_kpa
                 )
                 points_plot[key] = [temp], w_g_ka, plot_params
 

--- a/psychrochart/chart.py
+++ b/psychrochart/chart.py
@@ -346,12 +346,12 @@ def _gen_list_curves_range_temps(
 
 
 def _curve_constant_humidity_ratio(
-    dry_temps: List[float],
-    rh_percentage: Union[float, List[float]],
+    dry_temps: Iterable[float],
+    rh_percentage: Union[float, Iterable[float]],
     p_atm_kpa: float,
 ) -> List[float]:
     """Generate a curve (numpy array) of constant humidity ratio."""
-    if isinstance(rh_percentage, list):
+    if isinstance(rh_percentage, Iterable):
         return [
             1000.0
             * humidity_ratio(
@@ -901,11 +901,11 @@ class PsychroChart:
                 plot_params["label"] = point.get("label")
                 point = point["xy"]
             temp = point[0]
-            if isinstance(temp, list):
+            if isinstance(temp, Iterable):
                 w_g_ka = _curve_constant_humidity_ratio(
                     temp, point[1], self.p_atm_kpa
                 )
-                points_plot[key] = temp, w_g_ka, plot_params
+                points_plot[key] = list(temp), w_g_ka, plot_params
             else:
                 w_g_ka = _curve_constant_humidity_ratio(
                     [temp], rh_percentage=point[1], p_atm_kpa=self.p_atm_kpa

--- a/psychrochart/equations.py
+++ b/psychrochart/equations.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 """A library to make psychrometric charts and overlay information in them."""
+from math import atan, exp, log, sqrt
 from typing import Any
-from math import log, exp, atan, sqrt
 
 from psychrochart.util import iter_solver
-
 
 PRESSURE_STD_ATM_KPA = 101.325
 DELTA_TEMP_C_TO_KELVIN = 273.15
@@ -24,57 +23,63 @@ def pressure_by_altitude(altitude_m: float) -> float:
 
 
 def water_vapor_pressure(
-        w_kg_kga: float, p_atm_kpa: float=PRESSURE_STD_ATM_KPA) -> float:
+    w_kg_kga: float, p_atm_kpa: float = PRESSURE_STD_ATM_KPA
+) -> float:
     """Obtain the water vapor pressure from the humidity ratio (w_kg_kga).
 
     kPa, eq (38)
     2009 ASHRAE Handbook—Fundamentals (SI).
     """
-    humid_ratio_vap_pres = .621945
+    humid_ratio_vap_pres = 0.621945
     p_vapor_kpa = p_atm_kpa * w_kg_kga / (humid_ratio_vap_pres + w_kg_kga)
     return p_vapor_kpa
 
 
 def humidity_ratio(
-        p_vapor_kpa: float, p_atm_kpa: float=PRESSURE_STD_ATM_KPA) -> float:
+    p_vapor_kpa: float, p_atm_kpa: float = PRESSURE_STD_ATM_KPA
+) -> float:
     """Obtain the humidity ratio from the water vapor pressure.
 
     kg water vapor / kg dry air, eq (22)
     2009 ASHRAE Handbook—Fundamentals (SI).
     """
-    humid_ratio_vap_pres = .621945
+    humid_ratio_vap_pres = 0.621945
     w_kg_kga = humid_ratio_vap_pres * p_vapor_kpa / (p_atm_kpa - p_vapor_kpa)
     return w_kg_kga
 
 
-# TODO prec revision:
 def humidity_ratio_from_temps(
-        dry_bulb_temp_c: float, wet_bulb_temp_c: float,
-        p_atm_kpa: float=PRESSURE_STD_ATM_KPA) -> float:
+    dry_bulb_temp_c: float,
+    wet_bulb_temp_c: float,
+    p_atm_kpa: float = PRESSURE_STD_ATM_KPA,
+) -> float:
     """Obtain the specific humidity from the dry and wet bulb temperatures.
 
     kg water vapor / kg dry air, eqs (35) and (37)
     2009 ASHRAE Handbook—Fundamentals (SI).
     """
     w_sat_wet_bulb = humidity_ratio(
-        saturation_pressure_water_vapor(wet_bulb_temp_c), p_atm_kpa)
+        saturation_pressure_water_vapor(wet_bulb_temp_c), p_atm_kpa
+    )
     delta_t = dry_bulb_temp_c - wet_bulb_temp_c
-    # assert (delta_t >= 0)
+    assert delta_t > -0.00001
     factor_delta = 1.006 * delta_t
     if dry_bulb_temp_c > 0:
         num_1 = (2501 - 2.326 * wet_bulb_temp_c) * w_sat_wet_bulb
         denom_1 = 2501 + 1.86 * dry_bulb_temp_c - 4.186 * wet_bulb_temp_c
         w_kg_kga = (num_1 - factor_delta) / denom_1
     else:
-        num_2 = (2830 - .24 * wet_bulb_temp_c) * w_sat_wet_bulb
+        num_2 = (2830 - 0.24 * wet_bulb_temp_c) * w_sat_wet_bulb
         denom_2 = 2830 + 1.86 * dry_bulb_temp_c - 2.1 * wet_bulb_temp_c
         w_kg_kga = (num_2 - factor_delta) / denom_2
     return w_kg_kga
 
 
 def relative_humidity_from_temps(
-        dry_bulb_temp_c: float, wet_bulb_temp_c: float,
-        p_atm_kpa: float=PRESSURE_STD_ATM_KPA) -> float:
+    dry_bulb_temp_c: float,
+    wet_bulb_temp_c: float,
+    p_atm_kpa: float = PRESSURE_STD_ATM_KPA,
+) -> float:
     """Obtain the relative humidity from the dry and wet bulb temperatures.
 
     Ratio of the mole fraction of water vapor x_w in a given moist
@@ -84,46 +89,63 @@ def relative_humidity_from_temps(
     Eq (24) 2009 ASHRAE Handbook—Fundamentals (SI).
     """
     w_kg_kga = humidity_ratio_from_temps(
-        dry_bulb_temp_c, wet_bulb_temp_c, p_atm_kpa)
+        dry_bulb_temp_c, wet_bulb_temp_c, p_atm_kpa
+    )
     p_w_vapor = water_vapor_pressure(w_kg_kga, p_atm_kpa)
     p_sat = saturation_pressure_water_vapor(dry_bulb_temp_c)
-    return min(1., p_w_vapor / p_sat)
+    return min(1.0, p_w_vapor / p_sat)
 
 
 def specific_volume(
-        dry_temp_c: float, p_vapor_kpa: float,
-        p_atm_kpa: float=PRESSURE_STD_ATM_KPA) -> float:
+    dry_temp_c: float,
+    p_vapor_kpa: float,
+    p_atm_kpa: float = PRESSURE_STD_ATM_KPA,
+) -> float:
     """Obtain the specific volume v of a moist air mixture.
 
     m3 / kg dry air, eq. (28) 2009 ASHRAE Handbook—Fundamentals (SI).
     """
     w_kg_kga = humidity_ratio(p_vapor_kpa, p_atm_kpa)
-    specific_vol_m3_kga = (GAS_CONSTANT_R_DA
-                           * (dry_temp_c + DELTA_TEMP_C_TO_KELVIN)
-                           * (1 + 1.607858 * w_kg_kga) / p_atm_kpa)
+    specific_vol_m3_kga = (
+        GAS_CONSTANT_R_DA
+        * (dry_temp_c + DELTA_TEMP_C_TO_KELVIN)
+        * (1 + 1.607858 * w_kg_kga)
+        / p_atm_kpa
+    )
     return specific_vol_m3_kga
 
 
 def dry_temperature_for_specific_volume_of_moist_air(
-        w_kg_kga: float, specific_vol: float,
-        p_atm_kpa: float=PRESSURE_STD_ATM_KPA) -> float:
+    w_kg_kga: float,
+    specific_vol: float,
+    p_atm_kpa: float = PRESSURE_STD_ATM_KPA,
+) -> float:
     """Solve the dry bulb temp from humidity ratio and specific volume.
 
     ºC. Derived from eq. (28), 2009 ASHRAE Handbook—Fundamentals (SI).
     """
-    return (1741905.36576529 * p_atm_kpa * specific_vol
-            / (803929. * w_kg_kga + 500000.) - DELTA_TEMP_C_TO_KELVIN)
+    return (
+        1741905.36576529
+        * p_atm_kpa
+        * specific_vol
+        / (803929.0 * w_kg_kga + 500000.0)
+        - DELTA_TEMP_C_TO_KELVIN
+    )
 
 
 def density_water_vapor(p_vapor_kpa: float, dry_bulb_temp_c: float) -> float:
     """Density of water vapor."""
-    return (.0022 * p_vapor_kpa * 1000.
-            / (dry_bulb_temp_c + DELTA_TEMP_C_TO_KELVIN))
+    return (
+        0.0022
+        * p_vapor_kpa
+        * 1000.0
+        / (dry_bulb_temp_c + DELTA_TEMP_C_TO_KELVIN)
+    )
 
 
-def saturation_pressure_water_vapor(dry_temp_c: float,
-                                    mode: int=1,
-                                    logger: Any=None) -> float:
+def saturation_pressure_water_vapor(
+    dry_temp_c: float, mode: int = 1, logger: Any = None
+) -> float:
     """Saturation pressure of water vapor (kPa) from dry temperature.
 
     3 approximations:
@@ -131,9 +153,12 @@ def saturation_pressure_water_vapor(dry_temp_c: float,
       - mode 2: Simpler, values for T > 0 / T < 0, but same speed as 1
       - mode 3: More simpler, near 2x vs mode 1.
     """
+
     def _handle_error(exception):  # pragma: no cover
-        msg = 'OverflowError: {} with T={:.2f} °C, mode={}. ' \
-              'Changing to ASHRAE eqs'.format(exception, dry_temp_c, mode)
+        msg = (
+            f"OverflowError: {exception} with T={dry_temp_c:.2f} °C, "
+            f"mode={mode}. Changing to ASHRAE eqs"
+        )
         if logger is not None:
             logger.error(msg)  # pragma: no cover
         else:
@@ -149,9 +174,14 @@ def saturation_pressure_water_vapor(dry_temp_c: float,
             c4 = 4.1764768e-5
             c5 = -1.4452093e-8
             c6 = 6.5459673
-            ln_p_ws_pa = (c1 / abs_temp + c2 + c3 * abs_temp
-                          + c4 * abs_temp ** 2 + c5 * abs_temp ** 3
-                          + c6 * log(abs_temp))
+            ln_p_ws_pa = (
+                c1 / abs_temp
+                + c2
+                + c3 * abs_temp
+                + c4 * abs_temp ** 2
+                + c5 * abs_temp ** 3
+                + c6 * log(abs_temp)
+            )
         else:  # Eq (5) 2009 ASHRAE Handbook—Fundamentals (SI)
             c7 = -5.6745359e3
             c8 = 6.3925247
@@ -160,30 +190,44 @@ def saturation_pressure_water_vapor(dry_temp_c: float,
             c11 = 2.0747825e-9
             c12 = -9.4840240e-13
             c13 = 4.1635019
-            ln_p_ws_pa = (c7 / abs_temp + c8 + c9 * abs_temp
-                          + c10 * abs_temp ** 2 + c11 * abs_temp ** 3
-                          + c12 * abs_temp ** 4 + c13 * log(abs_temp))
+            ln_p_ws_pa = (
+                c7 / abs_temp
+                + c8
+                + c9 * abs_temp
+                + c10 * abs_temp ** 2
+                + c11 * abs_temp ** 3
+                + c12 * abs_temp ** 4
+                + c13 * log(abs_temp)
+            )
         return exp(ln_p_ws_pa) / 1000
     elif mode == 2:
         if dry_temp_c > 0:
-            return 610.5 * exp(
-                17.269 * dry_temp_c / (237.3 + dry_temp_c)) / 1000.
+            return (
+                610.5
+                * exp(17.269 * dry_temp_c / (237.3 + dry_temp_c))
+                / 1000.0
+            )
         else:
             try:
-                return 610.5 * exp(
-                    21.875 * dry_temp_c / (265.5 + dry_temp_c)) / 1000.
+                return (
+                    610.5
+                    * exp(21.875 * dry_temp_c / (265.5 + dry_temp_c))
+                    / 1000.0
+                )
             except OverflowError as exc:  # pragma: no cover
                 return _handle_error(exc)
     else:  # mode = 3
         try:
-            return 19314560 * 10. ** (-1779.75 / (237.3 + dry_temp_c))
+            return 19314560 * 10.0 ** (-1779.75 / (237.3 + dry_temp_c))
         except OverflowError as exc:  # pragma: no cover
             return _handle_error(exc)
 
 
 def enthalpy_moist_air(
-        dry_temp_c: float, p_vapor_kpa: float,
-        p_atm_kpa: float=PRESSURE_STD_ATM_KPA) -> float:
+    dry_temp_c: float,
+    p_vapor_kpa: float,
+    p_atm_kpa: float = PRESSURE_STD_ATM_KPA,
+) -> float:
     """Moist air specific enthalpy.
 
     KJ / kg. Eqs. (32), (30), (31) 2009 ASHRAE Handbook—Fundamentals (SI).
@@ -203,12 +247,13 @@ def enthalpy_moist_air(
 
 
 def dry_temperature_for_enthalpy_of_moist_air(
-        w_kg_kga: float, enthalpy: float) -> float:
+    w_kg_kga: float, enthalpy: float
+) -> float:
     """Solve the dry bulb temp from humidity ratio and specific enthalpy.
 
     ºC. Derived from eq. (32), 2009 ASHRAE Handbook—Fundamentals (SI).
     """
-    return 500. * (enthalpy - 2501.0 * w_kg_kga) / (930.0 * w_kg_kga + 503.0)
+    return 500.0 * (enthalpy - 2501.0 * w_kg_kga) / (930.0 * w_kg_kga + 503.0)
 
 
 def dew_point_temperature(p_w_kpa: float) -> float:
@@ -220,26 +265,32 @@ def dew_point_temperature(p_w_kpa: float) -> float:
     try:
         alpha = log(p_w_kpa)
     except ValueError:  # pragma: no cover
-        raise AssertionError("Bad water vapor pressure! ({} kPa)"
-                             .format(p_w_kpa))
+        raise AssertionError(f"Bad water vapor pressure! ({p_w_kpa} kPa)")
     c14 = 6.54
     c15 = 14.526
-    c16 = .7389
-    c17 = .09486
-    c18 = .4569
-    dew_point = (c14 + c15 * alpha + c16 * alpha ** 2 + c17 * alpha ** 3
-                 + c18 * p_w_kpa ** .1984)
-    if dew_point < 0:
-        # print('BAD dew_point: ', dew_point)
-        dew_point = 6.09 + 12.608 * alpha + .4959 * alpha ** 2
-        # print('GOOD dew_point: ', dew_point)
+    c16 = 0.7389
+    c17 = 0.09486
+    c18 = 0.4569
+    dew_point = (
+        c14
+        + c15 * alpha
+        + c16 * alpha ** 2
+        + c17 * alpha ** 3
+        + c18 * p_w_kpa ** 0.1984
+    )
+    if dew_point < 0.0:
+        dew_point = 6.09 + 12.608 * alpha + 0.4959 * alpha ** 2
+
     return dew_point
 
 
 def wet_bulb_temperature(
-        dry_temp_c: float, relative_humid: float,
-        p_atm_kpa: float=PRESSURE_STD_ATM_KPA,
-        num_iters_max=100, precision=0.00001) -> float:
+    dry_temp_c: float,
+    relative_humid: float,
+    p_atm_kpa: float = PRESSURE_STD_ATM_KPA,
+    num_iters_max=100,
+    precision=0.00001,
+) -> float:
     """Wet bulb temperature.
 
     Requires trial-and-error or numerical solution method
@@ -247,11 +298,15 @@ def wet_bulb_temperature(
     2009 ASHRAE Handbook—Fundamentals (SI).
     """
     out, _ = iter_solver(
-        dry_temp_c - 10, relative_humid,
+        dry_temp_c - 10,
+        relative_humid,
         lambda x: relative_humidity_from_temps(
-            dry_temp_c, x, p_atm_kpa=p_atm_kpa),
+            dry_temp_c, x, p_atm_kpa=p_atm_kpa
+        ),
         initial_increment=0.5,
-        num_iters_max=num_iters_max, precision=precision)
+        num_iters_max=num_iters_max,
+        precision=precision,
+    )
 
     # Wet bulb temperature can't be greater than dry bulb temp:
     if out > dry_temp_c:
@@ -260,22 +315,27 @@ def wet_bulb_temperature(
 
 
 def wet_bulb_temperature_empiric(
-        dry_temp_c: float, relative_humid: float) -> float:
+    dry_temp_c: float, relative_humid: float
+) -> float:
     """Empiric calculation of the wet bulb temperature for P_atm.
 
     Ref to (eq1) [http://journals.ametsoc.org/doi/pdf/10.1175/JAMC-D-11-0143.1]
     """
     rel_humid_p = relative_humid * 100
     if -2.33 * dry_temp_c + 28.33 > rel_humid_p:  # From Fig 3. Tw Error > 1 ºC
-        print('WARNING: The empiric formulation for wetbulb temperature at '
-              'this point ({}, {}) is out of range. Expect a '
-              'considerable error.'.format(dry_temp_c, relative_humid))
+        print(
+            f"WARNING: The empiric formulation for wetbulb temperature at "
+            f"this point ({dry_temp_c}, {relative_humid}) is out of range. "
+            f"Expect a considerable error :("
+        )
 
-    return (dry_temp_c * atan(0.151977 * sqrt(rel_humid_p + 8.313659))
-            + atan(dry_temp_c + rel_humid_p)
-            - atan(rel_humid_p - 1.676331)
-            + 0.00391838 * (rel_humid_p ** 1.5) * atan(0.023101 * rel_humid_p)
-            - 4.686035)
+    return (
+        dry_temp_c * atan(0.151977 * sqrt(rel_humid_p + 8.313659))
+        + atan(dry_temp_c + rel_humid_p)
+        - atan(rel_humid_p - 1.676331)
+        + 0.00391838 * (rel_humid_p ** 1.5) * atan(0.023101 * rel_humid_p)
+        - 4.686035
+    )
 
 
 # def degree_of_saturation(w_kg_kga, wsat_kg_kga):

--- a/psychrochart/util.py
+++ b/psychrochart/util.py
@@ -168,7 +168,7 @@ def solve_curves_with_iteration(
     func_init: Callable,
     func_eval: Callable,
     logger=print,
-):
+) -> List[float]:
     """Run the iteration solver for a list of objective values
     for the three types of curves solved with this method."""
     # family:= checking precision | initial_increment | precision
@@ -183,7 +183,7 @@ def solve_curves_with_iteration(
         )
 
     precision_comp, initial_increment, precision = families[family_name]
-    calc_points = []
+    calc_points: List[float] = []
     for objective in objective_values:
         try:
             calc_p, num_iter = iter_solver(

--- a/psychrochart/util.py
+++ b/psychrochart/util.py
@@ -3,24 +3,26 @@
 import json
 import os
 from time import time
-from typing import Callable, Union, Dict, Optional, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 
 NUM_ITERS_MAX = 100
 PATH_STYLES = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), 'chart_styles')
+    os.path.dirname(os.path.abspath(__file__)), "chart_styles"
+)
 
 DEFAULT_CHART_CONFIG_FILE = os.path.join(
-    PATH_STYLES, 'default_chart_config.json')
-ASHRAE_CHART_CONFIG_FILE = os.path.join(
-    PATH_STYLES, 'ashrae_chart_style.json')
+    PATH_STYLES, "default_chart_config.json"
+)
+ASHRAE_CHART_CONFIG_FILE = os.path.join(PATH_STYLES, "ashrae_chart_style.json")
 INTERIOR_CHART_CONFIG_FILE = os.path.join(
-    PATH_STYLES, 'interior_chart_style.json')
+    PATH_STYLES, "interior_chart_style.json"
+)
 MINIMAL_CHART_CONFIG_FILE = os.path.join(
-    PATH_STYLES, 'minimal_chart_style.json')
+    PATH_STYLES, "minimal_chart_style.json"
+)
 
-DEFAULT_ZONES_FILE = os.path.join(
-    PATH_STYLES, 'default_comfort_zones.json')
+DEFAULT_ZONES_FILE = os.path.join(PATH_STYLES, "default_comfort_zones.json")
 
 STYLES = {
     "ashrae": ASHRAE_CHART_CONFIG_FILE,
@@ -29,90 +31,105 @@ STYLES = {
     "minimal": MINIMAL_CHART_CONFIG_FILE,
 }
 
-TESTING_MODE = os.getenv('TESTING') is not None
+TESTING_MODE = os.getenv("TESTING") is not None
 
 
 def timeit(msg_log: str) -> Callable:
     """Wrap a method to print the execution time of a method call."""
+
     def real_deco(func) -> Callable:
         def wrapper(*args, **kwargs):
             tic = time()
             out = func(*args, **kwargs)
-            print(msg_log + ' TOOK: {:.3f} s'.format(time() - tic))
+            print(f"{msg_log} TOOK: {time() - tic:.3f} s")
             return out
+
         return wrapper
+
     return real_deco
 
 
-def _update_config(old_conf: dict, new_conf: dict,
-                   verbose: bool=False, recurs_idx: int=0) -> Dict:
+def _update_config(
+    old_conf: dict, new_conf: dict, verbose: bool = False, recurs_idx: int = 0
+) -> Dict:
     """Update a dict recursively."""
-    assert(recurs_idx < 3)
+    assert recurs_idx < 3
     if old_conf is None:
         return new_conf
     for key, value in old_conf.items():
         if key in new_conf:
             if isinstance(value, dict) and isinstance(new_conf[key], dict):
                 new_value = _update_config(
-                    old_conf[key], new_conf[key], verbose, recurs_idx + 1)
+                    old_conf[key], new_conf[key], verbose, recurs_idx + 1
+                )
             else:
                 new_value = new_conf[key]
                 if verbose and new_value != value:
-                    print('Update {}: from {} to {}'
-                          .format(key, value, new_value))
+                    print(f"Update {key}: from {value} to {new_value}")
             old_conf[key] = new_value
     if recurs_idx > 0:
-        old_conf.update({key: new_conf[key] for key in filter(
-            lambda x: x not in old_conf, new_conf)})
+        old_conf.update(
+            {
+                key: new_conf[key]
+                for key in filter(lambda x: x not in old_conf, new_conf)
+            }
+        )
     return old_conf
 
 
-def _load_config(new_config: Union[Dict, str]=None,
-                 default_config_file: str=None,
-                 verbose: bool=False) -> Dict:
+def _load_config(
+    new_config: Union[Dict, str] = None,
+    default_config_file: str = None,
+    verbose: bool = False,
+) -> Dict:
     """Load plot parameters from a JSON file."""
     if default_config_file is not None:
-        with open(default_config_file) as f:
+        with open(default_config_file, "r", encoding="utf-8") as f:
             config = json.load(f)
     else:
         config = None
     if new_config is not None:
         if isinstance(new_config, str):
             new_config_d = {}  # type: dict
-            if new_config.endswith('.json'):
-                with open(new_config) as f:
+            if new_config.endswith(".json"):
+                with open(new_config, "r", encoding="utf-8") as f:
                     new_config_d.update(json.load(f))
             elif new_config in STYLES:
-                with open(STYLES[new_config]) as f:
+                with open(STYLES[new_config], "r", encoding="utf-8") as f:
                     new_config_d.update(json.load(f))
             config = _update_config(config, new_config_d, verbose=verbose)
         else:
-            assert(isinstance(new_config, dict))
+            assert isinstance(new_config, dict)
             config = _update_config(config, new_config, verbose=verbose)
 
     return config
 
 
-def load_config(styles: Optional[Union[Dict, str]]=None,
-                verbose: bool=False) -> Dict:
+def load_config(
+    styles: Optional[Union[Dict, str]] = None, verbose: bool = False
+) -> Dict:
     """Load the plot params for the psychrometric chart."""
     return _load_config(
-        styles, default_config_file=DEFAULT_CHART_CONFIG_FILE,
-        verbose=verbose)
+        styles, default_config_file=DEFAULT_CHART_CONFIG_FILE, verbose=verbose
+    )
 
 
-def load_zones(zones: Optional[Union[Dict, str]]=DEFAULT_ZONES_FILE,
-               verbose: bool=False) -> Dict:
+def load_zones(
+    zones: Optional[Union[Dict, str]] = DEFAULT_ZONES_FILE,
+    verbose: bool = False,
+) -> Dict:
     """Load a zones JSON file to overlay in the psychrometric chart."""
     return _load_config(zones, verbose=verbose)
 
 
-def iter_solver(initial_value: float,
-                objective_value: float,
-                func_eval: Callable,
-                initial_increment: float=4.,
-                num_iters_max: int=NUM_ITERS_MAX,
-                precision: float=0.01) -> Tuple[float, int]:
+def iter_solver(
+    initial_value: float,
+    objective_value: float,
+    func_eval: Callable,
+    initial_increment: float = 4.0,
+    num_iters_max: int = NUM_ITERS_MAX,
+    precision: float = 0.01,
+) -> Tuple[float, int]:
     """Solve by iteration."""
     error = 100 * precision
     decreasing = True
@@ -138,54 +155,61 @@ def iter_solver(initial_value: float,
 
         if num_iter == num_iters_max:
             raise AssertionError(
-                'No convergence error after {} iterations! '
-                'Last value: {}, ∆: {}. Objective: {}, iter_value: {}'
-                .format(num_iter, value_calc, increment,
-                        objective_value, iteration_value))
+                f"No convergence error after {num_iter} iterations! "
+                f"Last value: {value_calc}, ∆: {increment}. "
+                f"Objective: {objective_value}, iter_value: {iteration_value}"
+            )
     return value_calc, num_iter
 
 
 def solve_curves_with_iteration(
-        family_name,
-        objective_values: List[float],
-        func_init: Callable,
-        func_eval: Callable,
-        logger=print):
+    family_name,
+    objective_values: List[float],
+    func_init: Callable,
+    func_eval: Callable,
+    logger=print,
+):
     """Run the iteration solver for a list of objective values
     for the three types of curves solved with this method."""
     # family:= checking precision | initial_increment | precision
-    families = {'DEW POINT': (0.0001, 0.1, 0.00000001),
-                'ENTHALPHY': (0.005, 25, 0.000002),
-                'CONSTANT VOLUME': (0.0025, 0.75, 0.00000025)}
+    families = {
+        "DEW POINT": (0.0001, 0.1, 0.00000001),
+        "ENTHALPHY": (0.005, 25, 0.000002),
+        "CONSTANT VOLUME": (0.0025, 0.75, 0.00000025),
+    }
     if family_name not in families.keys():  # pragma: no cover
-        raise AssertionError("Need a valid family of curves: {}".format(
-            families.keys()))
+        raise AssertionError(
+            f"Need a valid family of curves: {list(families.keys())}"
+        )
 
     precision_comp, initial_increment, precision = families[family_name]
     calc_points = []
     for objective in objective_values:
         try:
             calc_p, num_iter = iter_solver(
-                func_init(objective), objective,
+                func_init(objective),
+                objective,
                 func_eval=func_eval,
                 initial_increment=initial_increment,
                 num_iters_max=NUM_ITERS_MAX,
-                precision=precision)
+                precision=precision,
+            )
         except AssertionError as exc:  # pragma: no cover
-            logger("{} CONVERGENCE ERROR: {}".format(family_name, exc))
+            logger(f"{family_name} CONVERGENCE ERROR: {exc}")
             if TESTING_MODE:
                 raise exc
             else:
                 return calc_points
 
-        if (TESTING_MODE
-                and (abs(objective - func_eval(calc_p))
-                     > precision_comp)):  # pragma: no cover
-            msg = "{} BAD RESULT[#{}] (E={:.5f}): " \
-                  "objective: {:.5f}, calc_p: {:.5f}, " \
-                  "EVAL: {:.5f}".format(
-                    family_name, num_iter, abs(objective - func_eval(calc_p)),
-                    objective, calc_p, func_eval(calc_p))
+        if TESTING_MODE and (
+            abs(objective - func_eval(calc_p)) > precision_comp
+        ):  # pragma: no cover
+            msg = (
+                f"{family_name} BAD RESULT[#{num_iter}] "
+                f"(E={abs(objective - func_eval(calc_p)):.5f}): "
+                f"objective: {objective:.5f}, calc_p: {calc_p:.5f}, "
+                f"EVAL: {func_eval(calc_p):.5f}"
+            )
             logger(msg)
             raise AssertionError(msg)
         calc_points.append(calc_p)
@@ -194,15 +218,16 @@ def solve_curves_with_iteration(
 
 def mod_color(color: Union[Tuple, List], modification: float) -> List[float]:
     """Modify color with an alpha value or a darken/lighten percentage."""
-    if abs(modification) < .999:  # is alpha level
+    if abs(modification) < 0.999:  # is alpha level
         color = list(color[:3]) + [modification]
     else:
-        color = [max(0., min(1., c * (1 + modification / 100)))
-                 for c in color]
+        color = [
+            max(0.0, min(1.0, c * (1 + modification / 100))) for c in color
+        ]
     return color
 
 
-def f_range(start: float, end: float, step: float=1.) -> List[float]:
+def f_range(start: float, end: float, step: float = 1.0) -> List[float]:
     """Make list of floats like `numpy.arange`."""
     out = []
     while start < end:

--- a/psychrochart/util.py
+++ b/psychrochart/util.py
@@ -50,7 +50,7 @@ def timeit(msg_log: str) -> Callable:
 
 
 def _update_config(
-    old_conf: dict, new_conf: dict, verbose: bool = False, recurs_idx: int = 0
+    old_conf: dict, new_conf: dict, recurs_idx: int = 0
 ) -> Dict:
     """Update a dict recursively."""
     assert recurs_idx < 3
@@ -60,12 +60,10 @@ def _update_config(
         if key in new_conf:
             if isinstance(value, dict) and isinstance(new_conf[key], dict):
                 new_value = _update_config(
-                    old_conf[key], new_conf[key], verbose, recurs_idx + 1
+                    old_conf[key], new_conf[key], recurs_idx + 1
                 )
             else:
                 new_value = new_conf[key]
-                if verbose and new_value != value:
-                    print(f"Update {key}: from {value} to {new_value}")
             old_conf[key] = new_value
     if recurs_idx > 0:
         old_conf.update(
@@ -78,13 +76,11 @@ def _update_config(
 
 
 def _load_config(
-    new_config: Union[Dict, str] = None,
-    default_config_file: str = None,
-    verbose: bool = False,
+    new_config: Union[Dict, str] = None, default_config_file: str = None,
 ) -> Dict:
     """Load plot parameters from a JSON file."""
     if default_config_file is not None:
-        with open(default_config_file, "r", encoding="utf-8") as f:
+        with open(default_config_file, encoding="utf-8") as f:
             config = json.load(f)
     else:
         config = None
@@ -92,34 +88,27 @@ def _load_config(
         if isinstance(new_config, str):
             new_config_d = {}  # type: dict
             if new_config.endswith(".json"):
-                with open(new_config, "r", encoding="utf-8") as f:
+                with open(new_config, encoding="utf-8") as f:
                     new_config_d.update(json.load(f))
             elif new_config in STYLES:
-                with open(STYLES[new_config], "r", encoding="utf-8") as f:
+                with open(STYLES[new_config], encoding="utf-8") as f:
                     new_config_d.update(json.load(f))
-            config = _update_config(config, new_config_d, verbose=verbose)
+            config = _update_config(config, new_config_d)
         else:
             assert isinstance(new_config, dict)
-            config = _update_config(config, new_config, verbose=verbose)
+            config = _update_config(config, new_config)
 
     return config
 
 
-def load_config(
-    styles: Optional[Union[Dict, str]] = None, verbose: bool = False
-) -> Dict:
+def load_config(styles: Optional[Union[Dict, str]] = None) -> Dict:
     """Load the plot params for the psychrometric chart."""
-    return _load_config(
-        styles, default_config_file=DEFAULT_CHART_CONFIG_FILE, verbose=verbose
-    )
+    return _load_config(styles, default_config_file=DEFAULT_CHART_CONFIG_FILE)
 
 
-def load_zones(
-    zones: Optional[Union[Dict, str]] = DEFAULT_ZONES_FILE,
-    verbose: bool = False,
-) -> Dict:
+def load_zones(zones: Optional[Union[Dict, str]] = DEFAULT_ZONES_FILE) -> Dict:
     """Load a zones JSON file to overlay in the psychrometric chart."""
-    return _load_config(zones, verbose=verbose)
+    return _load_config(zones)
 
 
 def iter_solver(

--- a/psychrochart/util.py
+++ b/psychrochart/util.py
@@ -153,7 +153,7 @@ def iter_solver(
             value_calc += increment
         num_iter += 1
 
-        if num_iter == num_iters_max:
+        if num_iter == num_iters_max:  # pragma: no cover
             raise AssertionError(
                 f"No convergence error after {num_iter} iterations! "
                 f"Last value: {value_calc}, ∆: {increment}. "
@@ -191,7 +191,6 @@ def solve_curves_with_iteration(
                 objective,
                 func_eval=func_eval,
                 initial_increment=initial_increment,
-                num_iters_max=NUM_ITERS_MAX,
                 precision=precision,
             )
         except AssertionError as exc:  # pragma: no cover

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+addopts = -vv -s --cov-config=.coveragerc --cov=psychrochart --cov-report term --cov-report html
+log_level = INFO
+log_format = %(asctime)s %(levelname)s: (%(filename)s:%(lineno)s): %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
     ],
     packages=packages,
     package_data={"psychrochart": ["chart_styles/*.json"]},

--- a/setup.py
+++ b/setup.py
@@ -4,46 +4,45 @@ A python library to make psychrometric charts and overlay information in them.
 
 """
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 from psychrochart import __version__ as version
 
-
-packages = find_packages(exclude=['docs', '*tests*', 'notebooks', 'htmlcov'])
+packages = find_packages(exclude=["docs", "*tests*", "notebooks", "htmlcov"])
 
 basedir = os.path.dirname(os.path.abspath(__file__))
-with open(os.path.join(basedir, 'README.rst'), encoding='utf-8') as f:
+with open(os.path.join(basedir, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name='psychrochart',
+    name="psychrochart",
     version=version,
-    description='A Python 3 library to make psychrometric charts and overlay '
-                'information on them.',
-    long_description='\n' + long_description,
-    keywords='psychrometrics, moist, humid air, climate control, matplotlib',
-    author='Eugenio Panadero',
-    author_email='eugenio.panadero@gmail.com',
-    url='https://github.com/azogue/psychrochart',
-    license='MIT',
+    description="A Python 3 library to make psychrometric charts and overlay "
+    "information on them.",
+    long_description="\n" + long_description,
+    keywords="psychrometrics, moist, humid air, climate control, matplotlib",
+    author="Eugenio Panadero",
+    author_email="eugenio.panadero@gmail.com",
+    url="https://github.com/azogue/psychrochart",
+    license="MIT",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Education',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Information Technology',
-        'Intended Audience :: Science/Research',
-        'Topic :: Scientific/Engineering :: Information Analysis',
-        'Topic :: Scientific/Engineering :: Physics',
-        'Topic :: Scientific/Engineering :: Visualization',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Education",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Topic :: Scientific/Engineering :: Visualization",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     packages=packages,
-    package_data={
-        'psychrochart': ['chart_styles/*.json'],
-    },
-    install_requires=['matplotlib>=2.0.0'],
-    tests_require=['pytest>=3.0.0', 'pytest-cov'],
+    package_data={"psychrochart": ["chart_styles/*.json"]},
+    install_requires=["matplotlib>=3.1", "scipy>=1.3"],
+    tests_require=["pytest>=3.0.0", "pytest-cov"],
 )

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -86,7 +86,6 @@ class TestsPsychroCurves(TestCase):
         """Check the string representation of objects."""
         obj_repr = "<PsychroChart [0->50 °C, 0->40 gr/kg_da]>"
         data_chart = PsychroChart()
-        print(data_chart)
         self.assertEqual(str(data_chart), obj_repr)
 
         # noinspection PyUnresolvedReferences

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -11,7 +11,6 @@ from psychrochart.agg import PsychroChart
 from psychrochart.chart import PsychroCurve
 from psychrochart.util import f_range
 
-
 basedir = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -43,26 +42,29 @@ class TestsPsychroCurves(TestCase):
         # JSON import export
         json_curve = curve.to_json()
         curve_js = PsychroCurve()
-        self.assertEqual(str(curve_js), '<Empty PsychroCurve (label: None)>')
+        self.assertEqual(str(curve_js), "<Empty PsychroCurve (label: None)>")
         if curve_js:  # Existence test
             raise AssertionError()
         curve_js = curve_js.from_json(json_curve)
         if not curve_js:  # Existence test
             raise AssertionError()
-        self.assertEqual(str(curve_js),
-                         '<PsychroCurve 50 values (label: None)>')
+        self.assertEqual(
+            str(curve_js), "<PsychroCurve 50 values (label: None)>"
+        )
 
         self.assertCountEqual(curve.x_data, curve_js.x_data)
         self.assertListEqual(curve.x_data, curve_js.x_data)
         self.assertCountEqual(curve.y_data, curve_js.y_data)
         self.assertListEqual(curve.y_data, curve_js.y_data)
         self.assertDictEqual(curve.style, curve_js.style)
-        self.assertDictEqual(json.loads(json_curve),
-                             json.loads(curve_js.to_json()))
+        self.assertDictEqual(
+            json.loads(json_curve), json.loads(curve_js.to_json())
+        )
 
     def test_plot_curve(self):
         """Test the plotting of PsychroCurve objects."""
         import matplotlib.pyplot as plt
+
         x_data = f_range(0, 50, 1)
         y_data = f_range(0, 50, 1)
         style = {"color": "k", "linewidth": 0.5, "linestyle": "-"}
@@ -78,10 +80,7 @@ class TestsPsychroCurves(TestCase):
         vertical_curve.plot(ax)
 
         # Add label
-        vertical_curve.add_label(ax, 'TEST', va='baseline', ha='center')
-
-        # plt.savefig('test_line_vert.svg')
-        # plt.close()
+        vertical_curve.add_label(ax, "TEST", va="baseline", ha="center")
 
     def test_data_psychrochart(self):
         """Check the string representation of objects."""
@@ -93,28 +92,33 @@ class TestsPsychroCurves(TestCase):
         # noinspection PyUnresolvedReferences
         self.assertEqual(
             str(data_chart.constant_rh_data),
-            '<11 PsychroCurves (label: Constant relative humidity)>')
+            "<11 PsychroCurves (label: Constant relative humidity)>",
+        )
 
         self.assertEqual(
             str(data_chart.constant_v_data),
-            '<10 PsychroCurves (label: Constant specific volume)>')
+            "<10 PsychroCurves (label: Constant specific volume)>",
+        )
 
         self.assertEqual(
             str(data_chart.constant_wbt_data),
-            '<10 PsychroCurves (label: Constant wet bulb temperature)>')
+            "<10 PsychroCurves (label: Constant wet bulb temperature)>",
+        )
 
         self.assertEqual(
             str(data_chart.constant_h_data),
-            '<30 PsychroCurves (label: Constant enthalpy)>')
+            "<30 PsychroCurves (label: Constant enthalpy)>",
+        )
 
         self.assertEqual(
             str(data_chart.constant_dry_temp_data),
-            '<50 PsychroCurves (label: Dry bulb temperature)>')
+            "<50 PsychroCurves (label: Dry bulb temperature)>",
+        )
 
         self.assertEqual(
-            str(data_chart.saturation),
-            '<1 PsychroCurves (label: None)>')
+            str(data_chart.saturation), "<1 PsychroCurves (label: None)>"
+        )
         self.assertEqual(
             str(data_chart.saturation[0]),
-            '<PsychroCurve 51 values (label: None)>')
-
+            "<PsychroCurve 51 values (label: None)>",
+        )

--- a/tests/test_overlay_info.py
+++ b/tests/test_overlay_info.py
@@ -5,13 +5,13 @@ Tests plotting
 """
 import os
 from unittest import TestCase
+
 import numpy as np
 
 from psychrochart.agg import PsychroChart
 from psychrochart.util import load_config, timeit
 
-
-basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'charts')
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "charts")
 os.makedirs(basedir, exist_ok=True)
 
 
@@ -21,35 +21,38 @@ class TestsPsychroOverlay(TestCase):
     def test_custom_psychrochart(self):
         """Customize a chart with some additions"""
 
-        @timeit('test_custom_psychrochart')
+        @timeit("test_custom_psychrochart")
         def _make_chart():
             chart = PsychroChart("minimal")
 
             # Zones:
             zones_conf = {
-                "zones":
-                    [
-                        {
-                            "zone_type": "dbt-rh",
-                            "style": {"edgecolor": [1.0, 0.749, 0.0, 0.8],
-                                      "facecolor": [1.0, 0.749, 0.0, 0.2],
-                                      "linewidth": 2,
-                                      "linestyle": "--"},
-                            "points_x": [23, 28],
-                            "points_y": [40, 60],
-                            "label": "Summer"
+                "zones": [
+                    {
+                        "zone_type": "dbt-rh",
+                        "style": {
+                            "edgecolor": [1.0, 0.749, 0.0, 0.8],
+                            "facecolor": [1.0, 0.749, 0.0, 0.2],
+                            "linewidth": 2,
+                            "linestyle": "--",
                         },
-                        {
-                            "zone_type": "dbt-rh",
-                            "style": {"edgecolor": [0.498, 0.624, 0.8],
-                                      "facecolor": [0.498, 0.624, 1.0, 0.2],
-                                      "linewidth": 2,
-                                      "linestyle": "--"},
-                            "points_x": [18, 23],
-                            "points_y": [35, 55],
-                            "label": "Winter"
-                        }
-                    ]
+                        "points_x": [23, 28],
+                        "points_y": [40, 60],
+                        "label": "Summer",
+                    },
+                    {
+                        "zone_type": "dbt-rh",
+                        "style": {
+                            "edgecolor": [0.498, 0.624, 0.8],
+                            "facecolor": [0.498, 0.624, 1.0, 0.2],
+                            "linewidth": 2,
+                            "linestyle": "--",
+                        },
+                        "points_x": [18, 23],
+                        "points_y": [35, 55],
+                        "label": "Winter",
+                    },
+                ]
             }
             chart.append_zones(zones_conf)
 
@@ -59,50 +62,86 @@ class TestsPsychroOverlay(TestCase):
             # Vertical lines
             t_min, t_opt, t_max = 16, 23, 30
             chart.plot_vertical_dry_bulb_temp_line(
-                t_min, {"color": [0.0, 0.125, 0.376], "lw": 2, "ls": ':'},
-                '  TOO COLD ({}°C)'.format(t_min), ha='left',
-                loc=0., fontsize=14)
+                t_min,
+                {"color": [0.0, 0.125, 0.376], "lw": 2, "ls": ":"},
+                f"  TOO COLD ({t_min}°C)",
+                ha="left",
+                loc=0.0,
+                fontsize=14,
+            )
             chart.plot_vertical_dry_bulb_temp_line(
-                t_opt, {"color": [0.475, 0.612, 0.075], "lw": 2, "ls": ':'})
+                t_opt, {"color": [0.475, 0.612, 0.075], "lw": 2, "ls": ":"}
+            )
             chart.plot_vertical_dry_bulb_temp_line(
-                t_max, {"color": [1.0, 0.0, 0.247], "lw": 2, "ls": ':'},
-                'TOO HOT ({}°C)  '.format(t_max), ha='right', loc=1,
-                reverse=True, fontsize=14)
+                t_max,
+                {"color": [1.0, 0.0, 0.247], "lw": 2, "ls": ":"},
+                f"TOO HOT ({t_max}°C)  ",
+                ha="right",
+                loc=1,
+                reverse=True,
+                fontsize=14,
+            )
 
-            points = {'exterior': {'label': 'Exterior',
-                                   'style': {
-                                       'color': [0.855, 0.004, 0.278, 0.8],
-                                       'marker': 'X', 'markersize': 15},
-                                   'xy': (31.06, 32.9)},
-                      'exterior_estimated': {
-                          'label': 'Estimated (Weather service)',
-                          'style': {'color': [0.573, 0.106, 0.318, 0.5],
-                                    'marker': 'x', 'markersize': 10},
-                          'xy': (36.7, 25.0)},
-                      'interior': {'label': 'Interior',
-                                   'style': {
-                                       'color': [0.592, 0.745, 0.051, 0.9],
-                                       'marker': 'o', 'markersize': 30},
-                                   'xy': (29.42, 52.34)}}
-            connectors = [{'start': 'exterior',
-                           'end': 'exterior_estimated',
-                           'style': {'color': [0.573, 0.106, 0.318, 0.7],
-                                     "linewidth": 2, "linestyle": "-."}},
-                          {'start': 'exterior',
-                           'end': 'interior',
-                           'style': {'color': [0.855, 0.145, 0.114, 0.8],
-                                     "linewidth": 2, "linestyle": ":"}}]
+            points = {
+                "exterior": {
+                    "label": "Exterior",
+                    "style": {
+                        "color": [0.855, 0.004, 0.278, 0.8],
+                        "marker": "X",
+                        "markersize": 15,
+                    },
+                    "xy": (31.06, 32.9),
+                },
+                "exterior_estimated": {
+                    "label": "Estimated (Weather service)",
+                    "style": {
+                        "color": [0.573, 0.106, 0.318, 0.5],
+                        "marker": "x",
+                        "markersize": 10,
+                    },
+                    "xy": (36.7, 25.0),
+                },
+                "interior": {
+                    "label": "Interior",
+                    "style": {
+                        "color": [0.592, 0.745, 0.051, 0.9],
+                        "marker": "o",
+                        "markersize": 30,
+                    },
+                    "xy": (29.42, 52.34),
+                },
+            }
+            connectors = [
+                {
+                    "start": "exterior",
+                    "end": "exterior_estimated",
+                    "style": {
+                        "color": [0.573, 0.106, 0.318, 0.7],
+                        "linewidth": 2,
+                        "linestyle": "-.",
+                    },
+                },
+                {
+                    "start": "exterior",
+                    "end": "interior",
+                    "style": {
+                        "color": [0.855, 0.145, 0.114, 0.8],
+                        "linewidth": 2,
+                        "linestyle": ":",
+                    },
+                },
+            ]
 
             points_plot = chart.plot_points_dbt_rh(points, connectors)
-            print('Points in chart: %s' % points_plot)
+            print("Points in chart: %s" % points_plot)
 
             # Legend
             chart.plot_legend(
-                markerscale=.7, frameon=False, fontsize=10, labelspacing=1.2)
+                markerscale=0.7, frameon=False, fontsize=10, labelspacing=1.2
+            )
 
             # Save to disk
-            path_svg = os.path.join(
-                basedir, 'chart_overlay_style_minimal.svg')
+            path_svg = os.path.join(basedir, "chart_overlay_style_minimal.svg")
             chart.save(path_svg)
 
         _make_chart()
@@ -113,14 +152,14 @@ class TestsPsychroOverlay(TestCase):
         config = load_config("minimal")
 
         # Customization
-        config['limits']['pressure_kpa'] = 90.5
-        config['figure']['x_label'] = None
-        config['figure']['y_label'] = None
-        config['saturation']['linewidth'] = 3
-        config['chart_params']['with_constant_dry_temp'] = False
-        config['chart_params']['with_constant_humidity'] = False
-        config['chart_params']['with_constant_wet_temp'] = False
-        config['chart_params']['with_constant_h'] = False
+        config["limits"]["pressure_kpa"] = 90.5
+        config["figure"]["x_label"] = None
+        config["figure"]["y_label"] = None
+        config["saturation"]["linewidth"] = 3
+        config["chart_params"]["with_constant_dry_temp"] = False
+        config["chart_params"]["with_constant_humidity"] = False
+        config["chart_params"]["with_constant_wet_temp"] = False
+        config["chart_params"]["with_constant_h"] = False
 
         # Chart creation
         chart = PsychroChart(config)
@@ -128,52 +167,47 @@ class TestsPsychroOverlay(TestCase):
 
         # Zones:
         zones_conf = {
-            "zones":
-                [
-                    {
-                        "zone_type": "xy-points",
-                        "style": {"linewidth": 2,
-                                  "linestyle": "--",
-                                  # "color": [0.831, 0.839, 0.0],
-                                  "edgecolor": [0.498, 0.624, 0.8],
-                                  "facecolor": [0.498, 0.624, 1.0, 0.3]
-                                  },
-                        "points_x": [23, 28, 28, 24, 23],
-                        "points_y": [1, 3, 4, 4, 2],
-                        "label": "Custom"
+            "zones": [
+                {
+                    "zone_type": "xy-points",
+                    "style": {
+                        "linewidth": 2,
+                        "linestyle": "--",
+                        "edgecolor": [0.498, 0.624, 0.8],
+                        "facecolor": [0.498, 0.624, 1.0, 0.3],
                     },
-                    {
-                        "zone_type": "not_recognized_type",
-                        "label": "Bad zone"
-                    }
-                ]
+                    "points_x": [23, 28, 28, 24, 23],
+                    "points_y": [1, 3, 4, 4, 2],
+                    "label": "Custom",
+                },
+                {"zone_type": "not_recognized_type", "label": "Bad zone"},
+            ]
         }
         chart.append_zones(zones_conf)
 
         # Plotting
         chart.plot()
 
-        points = {'exterior': (31.06, 32.9),
-                  'exterior_estimated': (36.7, 25.0),
-                  'interior': (29.42, 52.34)}
+        points = {
+            "exterior": (31.06, 32.9),
+            "exterior_estimated": (36.7, 25.0),
+            "interior": (29.42, 52.34),
+        }
 
         convex_groups = [
-            (['exterior', 'exterior_estimated', 'interior'],
-             {},
-             {}
-             ),
+            (["exterior", "exterior_estimated", "interior"], {}, {}),
         ]
 
         points_plot = chart.plot_points_dbt_rh(
-            points, convex_groups=convex_groups)
-        print('Points in chart: %s' % points_plot)
+            points, convex_groups=convex_groups
+        )
+        print("Points in chart: %s" % points_plot)
 
         # Legend
-        chart.plot_legend(markerscale=1., fontsize=11, labelspacing=1.3)
+        chart.plot_legend(markerscale=1.0, fontsize=11, labelspacing=1.3)
 
         # Save to disk
-        path_svg = os.path.join(
-            basedir, 'chart_overlay_test.svg')
+        path_svg = os.path.join(basedir, "chart_overlay_test.svg")
         chart.save(path_svg)
 
     def test_custom_psychrochart_3(self):
@@ -189,45 +223,58 @@ class TestsPsychroOverlay(TestCase):
         # Plotting
         chart.plot()
 
-        arrows = {'exterior': [(31.06, 32.9), (29.06, 31.9)],
-                  'exterior_estimated': [(36.7, 25.0), (34.7, 30.0)],
-                  'interior': [(29.42, 52.34), (31.42, 57.34)]}
+        arrows = {
+            "exterior": [(31.06, 32.9), (29.06, 31.9)],
+            "exterior_estimated": [(36.7, 25.0), (34.7, 30.0)],
+            "interior": [(29.42, 52.34), (31.42, 57.34)],
+        }
 
         arrows_plot = chart.plot_arrows_dbt_rh(arrows)
-        print('arrows in chart: %s' % arrows_plot)
+        print("arrows in chart: %s" % arrows_plot)
 
         # Legend
-        chart.plot_legend(markerscale=1., fontsize=11, labelspacing=1.3)
+        chart.plot_legend(markerscale=1.0, fontsize=11, labelspacing=1.3)
 
         # Save to disk
-        path_svg = os.path.join(
-            basedir, 'test_chart_overlay_arrows_1.svg')
+        path_svg = os.path.join(basedir, "test_chart_overlay_arrows_1.svg")
         chart.save(path_svg)
 
         chart.remove_annotations()
         points_arrows = {
-            'exterior': {'label': 'Exterior',
-                         'style': {
-                             'color': [0.855, 0.004, 0.278, 0.8],
-                             'marker': 'X', 'markersize': 15},
-                         'xy': [(30.06, 34.9), (31.06, 35.9)]},
-            'exterior_estimated': {
-                'label': 'Estimated (Weather service)',
-                'style': {'color': [0.573, 0.106, 0.318, 0.5],
-                          'marker': 'x', 'markersize': 10},
-                'xy': [(32.7, 27.0), (31.7, 28.0)]},
-            'interior': {'label': 'Interior',
-                         'style': {
-                             'color': [0.592, 0.745, 0.051, 0.9],
-                             'marker': 'o', 'markersize': 30},
-                         'xy': [(29.92, 50.34), (28.92, 50.34)]}}
+            "exterior": {
+                "label": "Exterior",
+                "style": {
+                    "color": [0.855, 0.004, 0.278, 0.8],
+                    "marker": "X",
+                    "markersize": 15,
+                },
+                "xy": [(30.06, 34.9), (31.06, 35.9)],
+            },
+            "exterior_estimated": {
+                "label": "Estimated (Weather service)",
+                "style": {
+                    "color": [0.573, 0.106, 0.318, 0.5],
+                    "marker": "x",
+                    "markersize": 10,
+                },
+                "xy": [(32.7, 27.0), (31.7, 28.0)],
+            },
+            "interior": {
+                "label": "Interior",
+                "style": {
+                    "color": [0.592, 0.745, 0.051, 0.9],
+                    "marker": "o",
+                    "markersize": 30,
+                },
+                "xy": [(29.92, 50.34), (28.92, 50.34)],
+            },
+        }
 
         arrows_plot = chart.plot_arrows_dbt_rh(points_arrows)
-        print('arrows in chart 2: %s' % arrows_plot)
+        print("arrows in chart 2: %s" % arrows_plot)
 
         # Save to disk
-        path_svg = os.path.join(
-            basedir, 'test_chart_overlay_arrows_2.svg')
+        path_svg = os.path.join(basedir, "test_chart_overlay_arrows_2.svg")
         chart.save(path_svg)
 
     def test_custom_psychrochart_4(self):
@@ -236,7 +283,7 @@ class TestsPsychroOverlay(TestCase):
         config = load_config("minimal")
 
         # Customization
-        config['limits']['pressure_kpa'] = 90.5
+        config["limits"]["pressure_kpa"] = 90.5
 
         # Chart creation
         chart = PsychroChart(config)
@@ -245,36 +292,31 @@ class TestsPsychroOverlay(TestCase):
         # Plotting
         chart.plot()
 
-        points = {'exterior': (31.06, 32.9),
-                  'exterior_estimated': (36.7, 25.0),
-                  'interior': (29.42, 52.34)}
+        points = {
+            "exterior": (31.06, 32.9),
+            "exterior_estimated": (36.7, 25.0),
+            "interior": (29.42, 52.34),
+        }
 
         convex_groups_bad = [
-            (['exterior', 'interior'],
-             {},
-             {}
-             ),
+            (["exterior", "interior"], {}, {}),
         ]
         convex_groups_ok = [
-            (['exterior', 'exterior_estimated', 'interior'],
-             {},
-             {}
-             ),
+            (["exterior", "exterior_estimated", "interior"], {}, {}),
         ]
 
         points_plot = chart.plot_points_dbt_rh(
-            points, convex_groups=convex_groups_bad)
-        print('Points in chart: %s' % points_plot)
+            points, convex_groups=convex_groups_bad
+        )
+        print("Points in chart: %s" % points_plot)
 
-        chart.plot_points_dbt_rh(
-            points, convex_groups=convex_groups_ok)
+        chart.plot_points_dbt_rh(points, convex_groups=convex_groups_ok)
 
         # Legend
-        chart.plot_legend(markerscale=1., fontsize=11, labelspacing=1.3)
+        chart.plot_legend(markerscale=1.0, fontsize=11, labelspacing=1.3)
 
         # Save to disk
-        path_svg = os.path.join(
-            basedir, 'chart_overlay_test_convexhull.svg')
+        path_svg = os.path.join(basedir, "chart_overlay_test_convexhull.svg")
         chart.save(path_svg)
 
     def test_overlay_a_lot_of_points_1(self):
@@ -283,7 +325,7 @@ class TestsPsychroOverlay(TestCase):
         config = load_config("minimal")
 
         # Customization
-        config['limits']['pressure_kpa'] = 90.5
+        config["limits"]["pressure_kpa"] = 90.5
 
         # Chart creation
         chart = PsychroChart(config)
@@ -294,21 +336,24 @@ class TestsPsychroOverlay(TestCase):
 
         # Create a lot of points
         num_samples = 50000
-        # num_samples = 5000
         theta = np.linspace(0, 2 * np.pi, num_samples)
         r = np.random.rand(num_samples)
         x, y = 7 * r * np.cos(theta) + 25, 20 * r * np.sin(theta) + 50
 
-        points = {'test_series_1': (x, y)}
-        scatter_style = {'s': 5, 'alpha': .1,
-                         'color': 'darkorange', 'marker': '+'}
+        points = {"test_series_1": (x, y)}
+        scatter_style = {
+            "s": 5,
+            "alpha": 0.1,
+            "color": "darkorange",
+            "marker": "+",
+        }
 
-        # chart.plot_points_dbt_rh(points)
         chart.plot_points_dbt_rh(points, scatter_style=scatter_style)
 
         # Save to disk
         path_png = os.path.join(
-            basedir, 'chart_overlay_test_lot_of_points_1.png')
+            basedir, "chart_overlay_test_lot_of_points_1.png"
+        )
         chart.save(path_png)
 
     def test_overlay_a_lot_of_points_2(self):
@@ -317,7 +362,7 @@ class TestsPsychroOverlay(TestCase):
         config = load_config("minimal")
 
         # Customization
-        config['limits']['pressure_kpa'] = 90.5
+        config["limits"]["pressure_kpa"] = 90.5
 
         # Chart creation
         chart = PsychroChart(config)
@@ -332,25 +377,33 @@ class TestsPsychroOverlay(TestCase):
         r = np.random.rand(num_samples)
         x, y = 7 * r * np.cos(theta) + 25, 20 * r * np.sin(theta) + 50
 
-        scatter_style_1 = {'s': 20, 'alpha': .02,
-                           'color': 'darkblue', 'marker': 'o'}
-        scatter_style_2 = {'s': 10, 'alpha': .04,
-                           'color': 'darkorange', 'marker': '+'}
+        scatter_style_1 = {
+            "s": 20,
+            "alpha": 0.02,
+            "color": "darkblue",
+            "marker": "o",
+        }
+        scatter_style_2 = {
+            "s": 10,
+            "alpha": 0.04,
+            "color": "darkorange",
+            "marker": "+",
+        }
         x2, y2 = x + 5, y - 20
 
         points = {
-            'test_original': {
-                'label': 'Original',
-                'style': scatter_style_1,
-                'xy': (x, y)},
-            'test_displaced': {
-                'label': 'Displaced',
-                'xy': (x2, y2)}
+            "test_original": {
+                "label": "Original",
+                "style": scatter_style_1,
+                "xy": (x, y),
+            },
+            "test_displaced": {"label": "Displaced", "xy": (x2, y2)},
         }
         chart.plot_points_dbt_rh(points, scatter_style=scatter_style_2)
-        chart.plot_legend(markerscale=1., fontsize=11, labelspacing=1.3)
+        chart.plot_legend(markerscale=1.0, fontsize=11, labelspacing=1.3)
 
         # Save to disk
         path_png = os.path.join(
-            basedir, 'chart_overlay_test_lot_of_points.png')
+            basedir, "chart_overlay_test_lot_of_points.png"
+        )
         chart.save(path_png)

--- a/tests/test_overlay_info.py
+++ b/tests/test_overlay_info.py
@@ -131,9 +131,7 @@ class TestsPsychroOverlay(TestCase):
                     },
                 },
             ]
-
-            points_plot = chart.plot_points_dbt_rh(points, connectors)
-            print("Points in chart: %s" % points_plot)
+            chart.plot_points_dbt_rh(points, connectors)
 
             # Legend
             chart.plot_legend(
@@ -197,11 +195,7 @@ class TestsPsychroOverlay(TestCase):
         convex_groups = [
             (["exterior", "exterior_estimated", "interior"], {}, {}),
         ]
-
-        points_plot = chart.plot_points_dbt_rh(
-            points, convex_groups=convex_groups
-        )
-        print("Points in chart: %s" % points_plot)
+        chart.plot_points_dbt_rh(points, convex_groups=convex_groups)
 
         # Legend
         chart.plot_legend(markerscale=1.0, fontsize=11, labelspacing=1.3)
@@ -228,9 +222,7 @@ class TestsPsychroOverlay(TestCase):
             "exterior_estimated": [(36.7, 25.0), (34.7, 30.0)],
             "interior": [(29.42, 52.34), (31.42, 57.34)],
         }
-
-        arrows_plot = chart.plot_arrows_dbt_rh(arrows)
-        print("arrows in chart: %s" % arrows_plot)
+        chart.plot_arrows_dbt_rh(arrows)
 
         # Legend
         chart.plot_legend(markerscale=1.0, fontsize=11, labelspacing=1.3)
@@ -269,9 +261,7 @@ class TestsPsychroOverlay(TestCase):
                 "xy": [(29.92, 50.34), (28.92, 50.34)],
             },
         }
-
-        arrows_plot = chart.plot_arrows_dbt_rh(points_arrows)
-        print("arrows in chart 2: %s" % arrows_plot)
+        chart.plot_arrows_dbt_rh(points_arrows)
 
         # Save to disk
         path_svg = os.path.join(basedir, "test_chart_overlay_arrows_2.svg")
@@ -301,15 +291,10 @@ class TestsPsychroOverlay(TestCase):
         convex_groups_bad = [
             (["exterior", "interior"], {}, {}),
         ]
+        chart.plot_points_dbt_rh(points, convex_groups=convex_groups_bad)
         convex_groups_ok = [
             (["exterior", "exterior_estimated", "interior"], {}, {}),
         ]
-
-        points_plot = chart.plot_points_dbt_rh(
-            points, convex_groups=convex_groups_bad
-        )
-        print("Points in chart: %s" % points_plot)
-
         chart.plot_points_dbt_rh(points, convex_groups=convex_groups_ok)
 
         # Legend

--- a/tests/test_pickable_chart.py
+++ b/tests/test_pickable_chart.py
@@ -4,13 +4,12 @@ Test that Psychrochart object is pickable
 
 """
 import os
+import pickle
 from unittest import TestCase
 
 from psychrochart.agg import PsychroChart
-import pickle
 
-
-basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'charts')
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "charts")
 os.makedirs(basedir, exist_ok=True)
 
 
@@ -19,31 +18,28 @@ class TestsPicklePsychrochart(TestCase):
 
     def test_0_pickle_psychrochart(self):
         """Test the plot custom styling with JSON files/dicts."""
-        path_svg = os.path.join(
-            basedir, 'test_to_pickle.svg')
+        path_svg = os.path.join(basedir, "test_to_pickle.svg")
         chart = PsychroChart()
         chart.save(path_svg)
         chart.close_fig()
 
-        with open(os.path.join(basedir, 'chart.pickle'), 'wb') as f:
+        with open(os.path.join(basedir, "chart.pickle"), "wb") as f:
             pickle.dump(chart, f)
 
     def test_1_unpickle_psychrochart(self):
         """Test the plot custom styling with dicts."""
-        with open(os.path.join(basedir, 'chart.pickle'), 'rb') as f:
+        with open(os.path.join(basedir, "chart.pickle"), "rb") as f:
             chart = pickle.load(f)
 
-        path_svg = os.path.join(
-            basedir, 'test_from_pickle.svg')
+        path_svg = os.path.join(basedir, "test_from_pickle.svg")
         chart.save(path_svg)
         chart.close_fig()
 
     def test_2_compare_psychrocharts(self):
         """Test the plot custom styling with dicts."""
-        with open(os.path.join(basedir, 'test_to_pickle.svg')) as f:
+        with open(os.path.join(basedir, "test_to_pickle.svg")) as f:
             chart_1 = f.read()
-        with open(os.path.join(basedir, 'test_from_pickle.svg')) as f:
+        with open(os.path.join(basedir, "test_from_pickle.svg")) as f:
             chart_2 = f.read()
 
         assert len(chart_1) == len(chart_2)
-        # assert chart_1 == chart_2  # ids change in every plot

--- a/tests/test_plot_chart.py
+++ b/tests/test_plot_chart.py
@@ -219,7 +219,6 @@ class TestsPsychroPlot(TestCase):
         chart.close_fig()
 
         for p in f_range(90.0, 105.0):
-            print(f"Trying with P: {p} kPa:")
             custom_style["limits"]["pressure_kpa"] = p
             PsychroChart(custom_style, logger=logging, verbose=True)
 
@@ -376,7 +375,6 @@ class TestsPsychroPlot(TestCase):
         chart.close_fig()
 
         for p in f_range(90.0, 105.0, 1.0):
-            print(f"Trying with P: {p} kPa:")
             custom_style["limits"]["pressure_kpa"] = p
             PsychroChart(custom_style, logger=logging, verbose=True)
 

--- a/tests/test_plot_chart.py
+++ b/tests/test_plot_chart.py
@@ -8,8 +8,7 @@ from unittest import TestCase
 
 from psychrochart.agg import PsychroChart
 
-
-basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'charts')
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "charts")
 os.makedirs(basedir, exist_ok=True)
 
 
@@ -19,7 +18,8 @@ class TestsPsychroPlot(TestCase):
     def test_default_psychrochart(self):
         """Test the plot custom styling with JSON files/dicts."""
         path_svg_default = os.path.join(
-            basedir, 'test_default_psychrochart.svg')
+            basedir, "test_default_psychrochart.svg"
+        )
         chart = PsychroChart()
         chart.save(path_svg_default)
         chart.close_fig()
@@ -33,39 +33,36 @@ class TestsPsychroPlot(TestCase):
                 "title": None,
                 "x_label": None,
                 "y_label": None,
-                "partial_axis": False
+                "partial_axis": False,
             },
             "limits": {
                 "range_temp_c": [15, 25],
                 "range_humidity_g_kg": [0, 20],
                 "altitude_m": 900,
-                "step_temp": .2
+                "step_temp": 0.2,
             },
-            "saturation": {"color": [0, .3, 1.], "linewidth": 2},
-            "constant_rh": {"color": [0.0, 0.498, 1.0, .7], "linewidth": 2.5,
-                            "linestyle": ":"},
-
+            "saturation": {"color": [0, 0.3, 1.0], "linewidth": 2},
+            "constant_rh": {
+                "color": [0.0, 0.498, 1.0, 0.7],
+                "linewidth": 2.5,
+                "linestyle": ":",
+            },
             "chart_params": {
                 "with_constant_rh": True,
                 "constant_rh_curves": [25, 50, 75],
                 "constant_rh_labels": [25, 50, 75],
-
                 "with_constant_v": False,
                 "with_constant_h": False,
-                # "with_constant_wet_temp": False,
                 "range_wet_temp": [-10, 30],
-                # "constant_wet_temp_labels": [5, 10, 15, 20],
-                # "with_constant_dry_temp": False,
                 "constant_humid_label_include_limits": False,
-                "with_zones": False
-            }
+                "with_zones": False,
+            },
         }
         chart = PsychroChart(custom_style)
         chart.plot()
         chart.plot_legend()
 
-        path_png = os.path.join(
-            basedir, 'test_custom_psychrochart.png')
+        path_png = os.path.join(basedir, "test_custom_psychrochart.png")
         chart.save(path_png, transparent=True)
         chart.close_fig()
 
@@ -75,114 +72,155 @@ class TestsPsychroPlot(TestCase):
         from psychrochart.util import f_range
 
         custom_style = {
-            'chart_params': {
-                'constant_h_label': None,
-                'constant_h_labels': [30, 40, 50, 60, 70, 80],
-                'constant_h_step': 5,
-                'constant_humid_label': None,
-                'constant_humid_label_include_limits': False,
-                'constant_humid_label_step': 5,
-                'constant_humid_step': 2.5,
-                'constant_rh_curves': [20, 40, 50, 60, 80],
-                'constant_rh_label': None,
-                'constant_rh_labels': [20, 30, 40, 50, 60],
-                'constant_rh_labels_loc': 0.5,
-                'constant_temp_label': None,
-                'constant_temp_label_include_limits': False,
-                'constant_temp_label_step': 10,
-                'constant_temp_step': 5,
-                'constant_v_label': None,
-                'constant_v_labels': [0.83, 0.84, 0.85, 0.86, 0.87, 0.88],
-                'constant_v_labels_loc': 0.1,
-                'constant_v_step': 0.01,
-                'constant_wet_temp_label': None,
-                'constant_wet_temp_labels': [10, 15, 20, 25],
-                'constant_wet_temp_step': 5,
-                'range_wet_temp': [10, 30],
-                'range_h': [10, 100],
-                'range_vol_m3_kg': [0.82, 0.9],
-                'with_constant_dry_temp': True,
-                'with_constant_h': True,
-                'with_constant_humidity': True,
-                'with_constant_rh': True,
-                'with_constant_v': True,
-                'with_constant_wet_temp': True,
-                'with_zones': False},
-            'constant_dry_temp': {'color': [0.855, 0.145, 0.114, 0.7],
-                                  'linestyle': ':',
-                                  'linewidth': 0.75},
-            'constant_h': {'color': [0.251, 0.0, 0.502, 0.7],
-                           'linestyle': '-',
-                           'linewidth': 2},
-            'constant_humidity': {'color': [0.0, 0.125, 0.376, 0.7],
-                                  'linestyle': ':',
-                                  'linewidth': 0.75},
-            'constant_rh': {'color': [0.0, 0.498, 1.0, 0.7],
-                            'linestyle': '-.',
-                            'linewidth': 2},
-            'constant_v': {'color': [0.0, 0.502, 0.337, 0.7],
-                           'linestyle': '-',
-                           'linewidth': 1},
-            'constant_wet_temp': {'color': [0.498, 0.875, 1.0, 0.7],
-                                  'linestyle': '-',
-                                  'linewidth': 1},
-            'figure': {'figsize': [16, 9],
-                       'partial_axis': True,
-                       'position': [0, 0, 1, 1],
-                       'title': None,
-                       'x_axis': {'color': [0.855, 0.145, 0.114],
-                                  'linestyle': '-',
-                                  'linewidth': 2},
-                       'x_axis_labels': {'color': [0.855, 0.145, 0.114],
-                                         'fontsize': 10},
-                       'x_axis_ticks': {'color': [0.855, 0.145, 0.114],
-                                        'direction': 'in',
-                                        'pad': -20},
-                       'x_label': None,
-                       'y_axis': {'color': [0.0, 0.125, 0.376],
-                                  'linestyle': '-', 'linewidth': 2},
-                       'y_axis_labels': {'color': [0.0, 0.125, 0.376],
-                                         'fontsize': 10},
-                       'y_axis_ticks': {'color': [0.0, 0.125, 0.376],
-                                        'direction': 'in',
-                                        'pad': -20},
-                       'y_label': None},
-            # 'limits': {'range_humidity_g_kg': [2.5, 17.5],
-            'limits': {'range_humidity_g_kg': [2.5, 20],
-                       'range_temp_c': [15, 35],
-                       'step_temp': 0.5,
-                       'pressure_kpa': 101.42},
-            'saturation': {'color': [0.855, 0.145, 0.114],
-                           'linestyle': '-',
-                           'linewidth': 5},
-            'zones': [{'label': 'Summer',
-                       'points_x': [23, 28],
-                       'points_y': [40, 60],
-                       'style': {'edgecolor': [1.0, 0.749, 0.0, 0.8],
-                                 'facecolor': [1.0, 0.749, 0.0, 0.2],
-                                 'linestyle': '--',
-                                 'linewidth': 2},
-                       'zone_type': 'dbt-rh'},
-                      {'label': 'Winter',
-                       'points_x': [18, 23],
-                       'points_y': [35, 55],
-                       'style': {'edgecolor': [0.498, 0.624, 0.8],
-                                 'facecolor': [0.498, 0.624, 1.0, 0.2],
-                                 'linestyle': '--',
-                                 'linewidth': 2},
-                       'zone_type': 'dbt-rh'}]}
+            "chart_params": {
+                "constant_h_label": None,
+                "constant_h_labels": [30, 40, 50, 60, 70, 80],
+                "constant_h_step": 5,
+                "constant_humid_label": None,
+                "constant_humid_label_include_limits": False,
+                "constant_humid_label_step": 5,
+                "constant_humid_step": 2.5,
+                "constant_rh_curves": [20, 40, 50, 60, 80],
+                "constant_rh_label": None,
+                "constant_rh_labels": [20, 30, 40, 50, 60],
+                "constant_rh_labels_loc": 0.5,
+                "constant_temp_label": None,
+                "constant_temp_label_include_limits": False,
+                "constant_temp_label_step": 10,
+                "constant_temp_step": 5,
+                "constant_v_label": None,
+                "constant_v_labels": [0.83, 0.84, 0.85, 0.86, 0.87, 0.88],
+                "constant_v_labels_loc": 0.1,
+                "constant_v_step": 0.01,
+                "constant_wet_temp_label": None,
+                "constant_wet_temp_labels": [10, 15, 20, 25],
+                "constant_wet_temp_step": 5,
+                "range_wet_temp": [10, 30],
+                "range_h": [10, 100],
+                "range_vol_m3_kg": [0.82, 0.9],
+                "with_constant_dry_temp": True,
+                "with_constant_h": True,
+                "with_constant_humidity": True,
+                "with_constant_rh": True,
+                "with_constant_v": True,
+                "with_constant_wet_temp": True,
+                "with_zones": False,
+            },
+            "constant_dry_temp": {
+                "color": [0.855, 0.145, 0.114, 0.7],
+                "linestyle": ":",
+                "linewidth": 0.75,
+            },
+            "constant_h": {
+                "color": [0.251, 0.0, 0.502, 0.7],
+                "linestyle": "-",
+                "linewidth": 2,
+            },
+            "constant_humidity": {
+                "color": [0.0, 0.125, 0.376, 0.7],
+                "linestyle": ":",
+                "linewidth": 0.75,
+            },
+            "constant_rh": {
+                "color": [0.0, 0.498, 1.0, 0.7],
+                "linestyle": "-.",
+                "linewidth": 2,
+            },
+            "constant_v": {
+                "color": [0.0, 0.502, 0.337, 0.7],
+                "linestyle": "-",
+                "linewidth": 1,
+            },
+            "constant_wet_temp": {
+                "color": [0.498, 0.875, 1.0, 0.7],
+                "linestyle": "-",
+                "linewidth": 1,
+            },
+            "figure": {
+                "figsize": [16, 9],
+                "partial_axis": True,
+                "position": [0, 0, 1, 1],
+                "title": None,
+                "x_axis": {
+                    "color": [0.855, 0.145, 0.114],
+                    "linestyle": "-",
+                    "linewidth": 2,
+                },
+                "x_axis_labels": {
+                    "color": [0.855, 0.145, 0.114],
+                    "fontsize": 10,
+                },
+                "x_axis_ticks": {
+                    "color": [0.855, 0.145, 0.114],
+                    "direction": "in",
+                    "pad": -20,
+                },
+                "x_label": None,
+                "y_axis": {
+                    "color": [0.0, 0.125, 0.376],
+                    "linestyle": "-",
+                    "linewidth": 2,
+                },
+                "y_axis_labels": {
+                    "color": [0.0, 0.125, 0.376],
+                    "fontsize": 10,
+                },
+                "y_axis_ticks": {
+                    "color": [0.0, 0.125, 0.376],
+                    "direction": "in",
+                    "pad": -20,
+                },
+                "y_label": None,
+            },
+            "limits": {
+                "range_humidity_g_kg": [2.5, 20],
+                "range_temp_c": [15, 35],
+                "step_temp": 0.5,
+                "pressure_kpa": 101.42,
+            },
+            "saturation": {
+                "color": [0.855, 0.145, 0.114],
+                "linestyle": "-",
+                "linewidth": 5,
+            },
+            "zones": [
+                {
+                    "label": "Summer",
+                    "points_x": [23, 28],
+                    "points_y": [40, 60],
+                    "style": {
+                        "edgecolor": [1.0, 0.749, 0.0, 0.8],
+                        "facecolor": [1.0, 0.749, 0.0, 0.2],
+                        "linestyle": "--",
+                        "linewidth": 2,
+                    },
+                    "zone_type": "dbt-rh",
+                },
+                {
+                    "label": "Winter",
+                    "points_x": [18, 23],
+                    "points_y": [35, 55],
+                    "style": {
+                        "edgecolor": [0.498, 0.624, 0.8],
+                        "facecolor": [0.498, 0.624, 1.0, 0.2],
+                        "linestyle": "--",
+                        "linewidth": 2,
+                    },
+                    "zone_type": "dbt-rh",
+                },
+            ],
+        }
         chart = PsychroChart(custom_style, logger=logging, verbose=True)
         chart.plot()
         chart.plot_legend()
 
-        path_png = os.path.join(
-            basedir, 'test_custom_psychrochart_2.png')
+        path_png = os.path.join(basedir, "test_custom_psychrochart_2.png")
         chart.save(path_png, transparent=True)
         chart.close_fig()
 
-        for p in f_range(90., 105., 1.):
-            print('Trying with P: {} kPa:'.format(p))
-            custom_style['limits']['pressure_kpa'] = p
+        for p in f_range(90.0, 105.0):
+            print(f"Trying with P: {p} kPa:")
+            custom_style["limits"]["pressure_kpa"] = p
             PsychroChart(custom_style, logger=logging, verbose=True)
 
     def test_custom_style_psychrochart_3(self):
@@ -191,137 +229,176 @@ class TestsPsychroPlot(TestCase):
         from psychrochart.util import f_range
 
         custom_style = {
-            'chart_params': {
-                'constant_h_label': None,
-                'constant_h_labels': [-25, -15, 0, 10, 15],
-                'constant_h_step': 5,
-                'constant_humid_label': None,
-                'constant_humid_label_include_limits': False,
-                'constant_humid_label_step': 1,
-                'constant_humid_step': 0.5,
-                'constant_rh_curves': [10, 20, 40, 50, 60, 80, 90],
-                'constant_rh_label': None,
-                'constant_rh_labels': [20, 40, 60],
-                'constant_rh_labels_loc': 0.8,
-                'constant_temp_label': None,
-                'constant_temp_label_include_limits': False,
-                'constant_temp_label_step': 5,
-                'constant_temp_step': 5,
-                'constant_v_label': None,
-                'constant_v_labels': [0.74, 0.76, 0.78, 0.8],
-                'constant_v_labels_loc': 0.01,
-                'constant_v_step': 0.01,
-                'constant_wet_temp_label': None,
-                'constant_wet_temp_labels': [-15, -10, -5, 0],
-                'constant_wet_temp_step': 5,
-                'range_wet_temp': [-25, 5],
-                'range_h': [-30, 20],
-                'range_vol_m3_kg': [0.7, 0.82],
-                'with_constant_dry_temp': True,
-                'with_constant_h': True,
-                'with_constant_humidity': True,
-                'with_constant_rh': True,
-                'with_constant_v': True,
-                'with_constant_wet_temp': True,
-                'with_zones': False},
-            'constant_dry_temp': {'color': [0.855, 0.145, 0.114, 0.7],
-                                  'linestyle': ':',
-                                  'linewidth': 0.75},
-            'constant_h': {'color': [0.251, 0.0, 0.502, 0.7],
-                           'linestyle': '-',
-                           'linewidth': 2},
-            'constant_humidity': {'color': [0.0, 0.125, 0.376, 0.7],
-                                  'linestyle': ':',
-                                  'linewidth': 0.75},
-            'constant_rh': {'color': [0.0, 0.498, 1.0, 0.7],
-                            'linestyle': '-.',
-                            'linewidth': 2},
-            'constant_v': {'color': [0.0, 0.502, 0.337, 0.7],
-                           'linestyle': '-',
-                           'linewidth': 1},
-            'constant_wet_temp': {'color': [0.498, 0.875, 1.0, 0.7],
-                                  'linestyle': '-',
-                                  'linewidth': 1},
-            'figure': {'figsize': [16, 9],
-                       'partial_axis': True,
-                       'position': [0, 0, 1, 1],
-                       'title': None,
-                       'x_axis': {'color': [0.855, 0.145, 0.114],
-                                  'linestyle': '-',
-                                  'linewidth': 2},
-                       'x_axis_labels': {'color': [0.855, 0.145, 0.114],
-                                         'fontsize': 10},
-                       'x_axis_ticks': {'color': [0.855, 0.145, 0.114],
-                                        'direction': 'in',
-                                        'pad': -20},
-                       'x_label': None,
-                       'y_axis': {'color': [0.0, 0.125, 0.376],
-                                  'linestyle': '-', 'linewidth': 2},
-                       'y_axis_labels': {'color': [0.0, 0.125, 0.376],
-                                         'fontsize': 10},
-                       'y_axis_ticks': {'color': [0.0, 0.125, 0.376],
-                                        'direction': 'in',
-                                        'pad': -20},
-                       'y_label': None},
-            # 'limits': {'range_humidity_g_kg': [2.5, 17.5],
-            'limits': {'range_humidity_g_kg': [0, 3],
-                       'range_temp_c': [-30, 10],
-                       'step_temp': 0.5,
-                       'pressure_kpa': 101.42},
-            'saturation': {'color': [0.855, 0.145, 0.114],
-                           'linestyle': '-',
-                           'linewidth': 5},
-            'zones': [{'label': 'Summer',
-                       'points_x': [23, 28],
-                       'points_y': [40, 60],
-                       'style': {'edgecolor': [1.0, 0.749, 0.0, 0.8],
-                                 'facecolor': [1.0, 0.749, 0.0, 0.2],
-                                 'linestyle': '--',
-                                 'linewidth': 2},
-                       'zone_type': 'dbt-rh'},
-                      {'label': 'Winter',
-                       'points_x': [18, 23],
-                       'points_y': [35, 55],
-                       'style': {'edgecolor': [0.498, 0.624, 0.8],
-                                 'facecolor': [0.498, 0.624, 1.0, 0.2],
-                                 'linestyle': '--',
-                                 'linewidth': 2},
-                       'zone_type': 'dbt-rh'}]}
+            "chart_params": {
+                "constant_h_label": None,
+                "constant_h_labels": [-25, -15, 0, 10, 15],
+                "constant_h_step": 5,
+                "constant_humid_label": None,
+                "constant_humid_label_include_limits": False,
+                "constant_humid_label_step": 1,
+                "constant_humid_step": 0.5,
+                "constant_rh_curves": [10, 20, 40, 50, 60, 80, 90],
+                "constant_rh_label": None,
+                "constant_rh_labels": [20, 40, 60],
+                "constant_rh_labels_loc": 0.8,
+                "constant_temp_label": None,
+                "constant_temp_label_include_limits": False,
+                "constant_temp_label_step": 5,
+                "constant_temp_step": 5,
+                "constant_v_label": None,
+                "constant_v_labels": [0.74, 0.76, 0.78, 0.8],
+                "constant_v_labels_loc": 0.01,
+                "constant_v_step": 0.01,
+                "constant_wet_temp_label": None,
+                "constant_wet_temp_labels": [-15, -10, -5, 0],
+                "constant_wet_temp_step": 5,
+                "range_wet_temp": [-25, 5],
+                "range_h": [-30, 20],
+                "range_vol_m3_kg": [0.7, 0.82],
+                "with_constant_dry_temp": True,
+                "with_constant_h": True,
+                "with_constant_humidity": True,
+                "with_constant_rh": True,
+                "with_constant_v": True,
+                "with_constant_wet_temp": True,
+                "with_zones": False,
+            },
+            "constant_dry_temp": {
+                "color": [0.855, 0.145, 0.114, 0.7],
+                "linestyle": ":",
+                "linewidth": 0.75,
+            },
+            "constant_h": {
+                "color": [0.251, 0.0, 0.502, 0.7],
+                "linestyle": "-",
+                "linewidth": 2,
+            },
+            "constant_humidity": {
+                "color": [0.0, 0.125, 0.376, 0.7],
+                "linestyle": ":",
+                "linewidth": 0.75,
+            },
+            "constant_rh": {
+                "color": [0.0, 0.498, 1.0, 0.7],
+                "linestyle": "-.",
+                "linewidth": 2,
+            },
+            "constant_v": {
+                "color": [0.0, 0.502, 0.337, 0.7],
+                "linestyle": "-",
+                "linewidth": 1,
+            },
+            "constant_wet_temp": {
+                "color": [0.498, 0.875, 1.0, 0.7],
+                "linestyle": "-",
+                "linewidth": 1,
+            },
+            "figure": {
+                "figsize": [16, 9],
+                "partial_axis": True,
+                "position": [0, 0, 1, 1],
+                "title": None,
+                "x_axis": {
+                    "color": [0.855, 0.145, 0.114],
+                    "linestyle": "-",
+                    "linewidth": 2,
+                },
+                "x_axis_labels": {
+                    "color": [0.855, 0.145, 0.114],
+                    "fontsize": 10,
+                },
+                "x_axis_ticks": {
+                    "color": [0.855, 0.145, 0.114],
+                    "direction": "in",
+                    "pad": -20,
+                },
+                "x_label": None,
+                "y_axis": {
+                    "color": [0.0, 0.125, 0.376],
+                    "linestyle": "-",
+                    "linewidth": 2,
+                },
+                "y_axis_labels": {
+                    "color": [0.0, 0.125, 0.376],
+                    "fontsize": 10,
+                },
+                "y_axis_ticks": {
+                    "color": [0.0, 0.125, 0.376],
+                    "direction": "in",
+                    "pad": -20,
+                },
+                "y_label": None,
+            },
+            "limits": {
+                "range_humidity_g_kg": [0, 3],
+                "range_temp_c": [-30, 10],
+                "step_temp": 0.5,
+                "pressure_kpa": 101.42,
+            },
+            "saturation": {
+                "color": [0.855, 0.145, 0.114],
+                "linestyle": "-",
+                "linewidth": 5,
+            },
+            "zones": [
+                {
+                    "label": "Summer",
+                    "points_x": [23, 28],
+                    "points_y": [40, 60],
+                    "style": {
+                        "edgecolor": [1.0, 0.749, 0.0, 0.8],
+                        "facecolor": [1.0, 0.749, 0.0, 0.2],
+                        "linestyle": "--",
+                        "linewidth": 2,
+                    },
+                    "zone_type": "dbt-rh",
+                },
+                {
+                    "label": "Winter",
+                    "points_x": [18, 23],
+                    "points_y": [35, 55],
+                    "style": {
+                        "edgecolor": [0.498, 0.624, 0.8],
+                        "facecolor": [0.498, 0.624, 1.0, 0.2],
+                        "linestyle": "--",
+                        "linewidth": 2,
+                    },
+                    "zone_type": "dbt-rh",
+                },
+            ],
+        }
         chart = PsychroChart(custom_style, logger=logging, verbose=True)
         chart.plot()
         chart.plot_legend()
 
-        path_png = os.path.join(
-            basedir, 'test_custom_psychrochart_3.png')
+        path_png = os.path.join(basedir, "test_custom_psychrochart_3.png")
         chart.save(path_png, transparent=True)
         chart.close_fig()
 
-        for p in f_range(90., 105., 1.):
-            print('Trying with P: {} kPa:'.format(p))
-            custom_style['limits']['pressure_kpa'] = p
+        for p in f_range(90.0, 105.0, 1.0):
+            print(f"Trying with P: {p} kPa:")
+            custom_style["limits"]["pressure_kpa"] = p
             PsychroChart(custom_style, logger=logging, verbose=True)
 
     def test_default_styles_psychrochart(self):
         """Test the plot custom styling with JSON files."""
-        path_svg_ashrae = os.path.join(
-            basedir, 'test_ashrae_psychrochart.svg')
+        path_svg_ashrae = os.path.join(basedir, "test_ashrae_psychrochart.svg")
         chart = PsychroChart("ashrae")
         chart.plot()
         chart.save(path_svg_ashrae)
-        chart.save(path_svg_ashrae.replace('svg', 'png'), transparent=True)
+        chart.save(path_svg_ashrae.replace("svg", "png"), transparent=True)
         chart.close_fig()
 
-        path_svg_2 = os.path.join(
-            basedir, 'test_interior_psychrochart.svg')
+        path_svg_2 = os.path.join(basedir, "test_interior_psychrochart.svg")
         chart = PsychroChart("interior")
         chart.plot()
         chart.plot_legend(
-            markerscale=.7, frameon=False, fontsize=10, labelspacing=1.2)
+            markerscale=0.7, frameon=False, fontsize=10, labelspacing=1.2
+        )
         chart.save(path_svg_2)
         chart.close_fig()
 
-        path_svg_3 = os.path.join(
-            basedir, 'test_minimal_psychrochart.svg')
+        path_svg_3 = os.path.join(basedir, "test_minimal_psychrochart.svg")
         chart = PsychroChart("minimal")
         chart.plot()
         chart.plot_legend()

--- a/tests/test_profile_mem_reuse_chart.py
+++ b/tests/test_profile_mem_reuse_chart.py
@@ -4,46 +4,47 @@ Tests plotting
 
 """
 import os
+from time import sleep
 from unittest import TestCase
 
 from psychrochart.agg import PsychroChart
 from psychrochart.util import timeit
-# from memory_profiler import profile
-from time import sleep
 
-
-basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'charts')
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "charts")
 os.makedirs(basedir, exist_ok=True)
 
 
-@timeit('make_chart')
+@timeit("make_chart")
 def _make_chart(path_save=None):
     chart = PsychroChart("minimal")
     # Zones:
     zones_conf = {
-        "zones":
-            [
-                {
-                    "zone_type": "dbt-rh",
-                    "style": {"edgecolor": [1.0, 0.749, 0.0, 0.8],
-                              "facecolor": [1.0, 0.749, 0.0, 0.2],
-                              "linewidth": 2,
-                              "linestyle": "--"},
-                    "points_x": [23, 28],
-                    "points_y": [40, 60],
-                    "label": "Summer"
+        "zones": [
+            {
+                "zone_type": "dbt-rh",
+                "style": {
+                    "edgecolor": [1.0, 0.749, 0.0, 0.8],
+                    "facecolor": [1.0, 0.749, 0.0, 0.2],
+                    "linewidth": 2,
+                    "linestyle": "--",
                 },
-                {
-                    "zone_type": "dbt-rh",
-                    "style": {"edgecolor": [0.498, 0.624, 0.8],
-                              "facecolor": [0.498, 0.624, 1.0, 0.2],
-                              "linewidth": 2,
-                              "linestyle": "--"},
-                    "points_x": [18, 23],
-                    "points_y": [35, 55],
-                    "label": "Winter"
-                }
-            ]
+                "points_x": [23, 28],
+                "points_y": [40, 60],
+                "label": "Summer",
+            },
+            {
+                "zone_type": "dbt-rh",
+                "style": {
+                    "edgecolor": [0.498, 0.624, 0.8],
+                    "facecolor": [0.498, 0.624, 1.0, 0.2],
+                    "linewidth": 2,
+                    "linestyle": "--",
+                },
+                "points_x": [18, 23],
+                "points_y": [35, 55],
+                "label": "Winter",
+            },
+        ]
     }
     chart.append_zones(zones_conf)
     # Plotting
@@ -51,84 +52,124 @@ def _make_chart(path_save=None):
     # Vertical lines
     t_min, t_opt, t_max = 16, 23, 30
     chart.plot_vertical_dry_bulb_temp_line(
-        t_min, {"color": [0.0, 0.125, 0.376], "lw": 2, "ls": ':'},
-        '  TOO COLD ({}°C)'.format(t_min), ha='left', loc=0., fontsize=14)
+        t_min,
+        {"color": [0.0, 0.125, 0.376], "lw": 2, "ls": ":"},
+        f"  TOO COLD ({t_min}°C)",
+        ha="left",
+        loc=0.0,
+        fontsize=14,
+    )
     chart.plot_vertical_dry_bulb_temp_line(
-        t_opt, {"color": [0.475, 0.612, 0.075], "lw": 2, "ls": ':'})
+        t_opt, {"color": [0.475, 0.612, 0.075], "lw": 2, "ls": ":"}
+    )
     chart.plot_vertical_dry_bulb_temp_line(
-        t_max, {"color": [1.0, 0.0, 0.247], "lw": 2, "ls": ':'},
-        'TOO HOT ({}°C)  '.format(t_max), ha='right', loc=1,
-        reverse=True, fontsize=14)
+        t_max,
+        {"color": [1.0, 0.0, 0.247], "lw": 2, "ls": ":"},
+        f"TOO HOT ({t_max}°C)  ",
+        ha="right",
+        loc=1,
+        reverse=True,
+        fontsize=14,
+    )
     # Save to disk the base chart
     if path_save is not None:
-        path_svg = os.path.join(
-            basedir, path_save)
+        path_svg = os.path.join(basedir, path_save)
         chart.save(path_svg)
     return chart
 
 
-@timeit('add_points')
+@timeit("add_points")
 def _add_points(chart, with_connectors=True, path_save=None):
     if with_connectors:
         # Append points and connectors
-        points = {'exterior': {'label': 'Exterior',
-                               'style': {
-                                   'color': [0.855, 0.004, 0.278, 0.8],
-                                   'marker': 'X', 'markersize': 15},
-                               'xy': (31.06, 32.9)},
-                  'exterior_estimated': {
-                      'label': 'Estimated (Weather service)',
-                      'style': {'color': [0.573, 0.106, 0.318, 0.5],
-                                'marker': 'x', 'markersize': 10},
-                      'xy': (36.7, 25.0)},
-                  'interior': {'label': 'Interior',
-                               'style': {
-                                   'color': [0.592, 0.745, 0.051, 0.9],
-                                   'marker': 'o', 'markersize': 30},
-                               'xy': (29.42, 52.34)}}
-        connectors = [{'start': 'exterior',
-                       'end': 'exterior_estimated',
-                       'style': {'color': [0.573, 0.106, 0.318, 0.7],
-                                 "linewidth": 2, "linestyle": "-."}},
-                      {'start': 'exterior',
-                       'end': 'interior',
-                       'style': {'color': [0.855, 0.145, 0.114, 0.8],
-                                 "linewidth": 2, "linestyle": ":"}}]
-
-        convex_groups = [
-            (['exterior', 'exterior_estimated', 'interior'],
-             {'color': 'darkgreen', 'lw': 2, 'alpha': .5, 'ls': ':'},
-             {'color': 'darkgreen', 'lw': 0, 'alpha': .3}),
+        points = {
+            "exterior": {
+                "label": "Exterior",
+                "style": {
+                    "color": [0.855, 0.004, 0.278, 0.8],
+                    "marker": "X",
+                    "markersize": 15,
+                },
+                "xy": (31.06, 32.9),
+            },
+            "exterior_estimated": {
+                "label": "Estimated (Weather service)",
+                "style": {
+                    "color": [0.573, 0.106, 0.318, 0.5],
+                    "marker": "x",
+                    "markersize": 10,
+                },
+                "xy": (36.7, 25.0),
+            },
+            "interior": {
+                "label": "Interior",
+                "style": {
+                    "color": [0.592, 0.745, 0.051, 0.9],
+                    "marker": "o",
+                    "markersize": 30,
+                },
+                "xy": (29.42, 52.34),
+            },
+        }
+        connectors = [
+            {
+                "start": "exterior",
+                "end": "exterior_estimated",
+                "style": {
+                    "color": [0.573, 0.106, 0.318, 0.7],
+                    "linewidth": 2,
+                    "linestyle": "-.",
+                },
+            },
+            {
+                "start": "exterior",
+                "end": "interior",
+                "style": {
+                    "color": [0.855, 0.145, 0.114, 0.8],
+                    "linewidth": 2,
+                    "linestyle": ":",
+                },
+            },
         ]
 
-        points_plot = chart.plot_points_dbt_rh(points, connectors,
-                                               convex_groups=convex_groups)
+        convex_groups = [
+            (
+                ["exterior", "exterior_estimated", "interior"],
+                {"color": "darkgreen", "lw": 2, "alpha": 0.5, "ls": ":"},
+                {"color": "darkgreen", "lw": 0, "alpha": 0.3},
+            ),
+        ]
+
+        points_plot = chart.plot_points_dbt_rh(
+            points, connectors, convex_groups=convex_groups
+        )
     else:
-        points = {'exterior': (31.06, 32.9),
-                  'exterior_estimated': (36.7, 25.0),
-                  'interior': (29.42, 52.34)}
+        points = {
+            "exterior": (31.06, 32.9),
+            "exterior_estimated": (36.7, 25.0),
+            "interior": (29.42, 52.34),
+        }
         points_plot = chart.plot_points_dbt_rh(points)
-    print('Points in chart: %s' % points_plot)
+    print("Points in chart: %s" % points_plot)
     # Save to disk
     if path_save is not None:
         path_svg = os.path.join(basedir, path_save)
         chart.save(path_svg)
 
 
-@timeit('MAKE_CHARTS')
+@timeit("MAKE_CHARTS")
 def _make_charts(with_reuse=False):
-    name = 'test_reuse_chart_' if with_reuse else 'test_noreuse_chart_'
+    name = "test_reuse_chart_" if with_reuse else "test_noreuse_chart_"
     chart = _make_chart()
-    _add_points(chart, True, '{}_1.svg'.format(name))
+    _add_points(chart, True, f"{name}_1.svg")
 
     if with_reuse:
         chart.remove_annotations()
     else:
         chart = _make_chart()
-    _add_points(chart, False, '{}_2.svg'.format(name))
+    _add_points(chart, False, f"{name}_2.svg")
 
 
-# @profile
 def draw_chart(path_img, chart=None):
     if chart is None:
         chart = _make_chart()
@@ -142,37 +183,22 @@ class TestsPsychroReuseMem(TestCase):
 
     def test_reuse_psychrochart(self):
         """Customize a chart with some additions"""
-        print('make_charts(with_reuse=True)')
+        print("make_charts(with_reuse=True)")
         _make_charts(with_reuse=True)
 
     def test_no_reuse_psychrochart(self):
         """Customize a chart with some additions"""
-        print('make_charts(with_reuse=False)')
+        print("make_charts(with_reuse=False)")
         _make_charts(with_reuse=False)
 
     def test_redraw_psychrochart(self):
         """Test the workflow to redraw a chart."""
         sleep_time = 1
         counter = 0
-        print('Make initial chart')
+        print("Make initial chart")
         chart = _make_chart()
         while counter < 10:
-            print('Drawing chart #{}'.format(counter))
-            # draw_chart(None, chart)
-            # draw_chart('test_redraw_chart_1.png', chart)
-            draw_chart('test_redraw_chart_1.svg', chart)
+            print(f"Drawing chart #{counter}")
+            draw_chart("test_redraw_chart_1.svg", chart)
             counter += 1
             sleep(sleep_time)
-
-            # sleep(sleep_time)
-            # print('Brute force mode:')
-            # counter = 0
-            # while counter < 30:
-            #     print('Drawing new chart #{}'.format(counter))
-            #     draw_chart(None)
-            #     counter += 1
-            #     sleep(sleep_time)
-
-
-# if __name__ == '__main__':
-#     test_redraw_psychrochart()

--- a/tests/test_profile_mem_reuse_chart.py
+++ b/tests/test_profile_mem_reuse_chart.py
@@ -139,8 +139,7 @@ def _add_points(chart, with_connectors=True, path_save=None):
                 {"color": "darkgreen", "lw": 0, "alpha": 0.3},
             ),
         ]
-
-        points_plot = chart.plot_points_dbt_rh(
+        chart.plot_points_dbt_rh(
             points, connectors, convex_groups=convex_groups
         )
     else:
@@ -149,8 +148,7 @@ def _add_points(chart, with_connectors=True, path_save=None):
             "exterior_estimated": (36.7, 25.0),
             "interior": (29.42, 52.34),
         }
-        points_plot = chart.plot_points_dbt_rh(points)
-    print("Points in chart: %s" % points_plot)
+        chart.plot_points_dbt_rh(points)
     # Save to disk
     if path_save is not None:
         path_svg = os.path.join(basedir, path_save)
@@ -183,12 +181,10 @@ class TestsPsychroReuseMem(TestCase):
 
     def test_reuse_psychrochart(self):
         """Customize a chart with some additions"""
-        print("make_charts(with_reuse=True)")
         _make_charts(with_reuse=True)
 
     def test_no_reuse_psychrochart(self):
         """Customize a chart with some additions"""
-        print("make_charts(with_reuse=False)")
         _make_charts(with_reuse=False)
 
     def test_redraw_psychrochart(self):

--- a/tests/test_psychrometrics.py
+++ b/tests/test_psychrometrics.py
@@ -5,7 +5,6 @@ Test Cases for psychrometric equations
 """
 from unittest import TestCase
 
-
 # http://www.engineeringtoolbox.com/water-vapor-saturation-pressure-d_599.html
 DRY_TEMP_PSAT_KPA = {
     0: 0.6105,
@@ -19,7 +18,7 @@ DRY_TEMP_PSAT_KPA = {
     70: 31.16,
     80: 47.34,
     90: 70.10,
-    100: 101.3
+    100: 101.3,
 }
 
 # http://www.engineeringtoolbox.com/air-altitude-density-volume-d_195.html
@@ -39,7 +38,7 @@ ALTITUDE_M_PRESSURE_KPA = {
     1500: 84.3,
     1800: 81.2,
     2100: 78.1,
-    2400: 75.2
+    2400: 75.2,
 }
 
 # http://www.engineeringtoolbox.com/humidity-ratio-air-d_686.html
@@ -50,7 +49,7 @@ TEMP_SAT_PRESS_HUMID_RATIO = {
     15: (1701, 0.01062),
     20: (2333, 0.014659),
     25: (3130, 0.019826),
-    30: (4234, 0.027125)
+    30: (4234, 0.027125),
 }
 
 # http://www.engineeringtoolbox.com/water-vapor-saturation-pressure-air-d_689.html
@@ -70,20 +69,22 @@ TEMP_PRESS_PA_DENS_G_KG = {
     140: (358137, 1910),
     160: (611728, 3110),
     180: (990022, 4800),
-    200: (1529627, 7110)
+    200: (1529627, 7110),
 }
 
+# fmt: off
 # http://www.engineeringtoolbox.com/humidity-measurement-d_561.html
 REL_HUMID_WITH_TEMP_WET_DELTA_TEMPS = {
- 15: {1: 90, 2: 80, 3: 71, 4: 62, 5: 53, 6: 44, 7: 36, 8: 28, 9: 21, 10: 13},
- 18: {1: 91, 2: 82, 3: 73, 4: 65, 5: 57, 6: 49, 7: 42, 8: 34, 9: 27, 10: 20},
- 20: {1: 91, 2: 83, 3: 75, 4: 67, 5: 59, 6: 52, 7: 45, 8: 38, 9: 31, 10: 25},
- 22: {1: 92, 2: 84, 3: 76, 4: 68, 5: 61, 6: 54, 7: 47, 8: 41, 9: 34, 10: 28},
- 25: {1: 92, 2: 85, 3: 77, 4: 70, 5: 64, 6: 57, 7: 51, 8: 45, 9: 39, 10: 33},
- 27: {1: 92, 2: 85, 3: 78, 4: 71, 5: 65, 6: 59, 7: 53, 8: 47, 9: 41, 10: 36},
- 30: {1: 93, 2: 86, 3: 79, 4: 73, 5: 67, 6: 61, 7: 55, 8: 50, 9: 45, 10: 40},
- 33: {1: 93, 2: 87, 3: 80, 4: 74, 5: 69, 6: 63, 7: 58, 8: 53, 9: 48, 10: 43}
+    15: {1: 90, 2: 80, 3: 71, 4: 62, 5: 53, 6: 44, 7: 36, 8: 28, 9: 21, 10: 13},  # noqa E501
+    18: {1: 91, 2: 82, 3: 73, 4: 65, 5: 57, 6: 49, 7: 42, 8: 34, 9: 27, 10: 20},  # noqa E501
+    20: {1: 91, 2: 83, 3: 75, 4: 67, 5: 59, 6: 52, 7: 45, 8: 38, 9: 31, 10: 25},  # noqa E501
+    22: {1: 92, 2: 84, 3: 76, 4: 68, 5: 61, 6: 54, 7: 47, 8: 41, 9: 34, 10: 28},  # noqa E501
+    25: {1: 92, 2: 85, 3: 77, 4: 70, 5: 64, 6: 57, 7: 51, 8: 45, 9: 39, 10: 33},  # noqa E501
+    27: {1: 92, 2: 85, 3: 78, 4: 71, 5: 65, 6: 59, 7: 53, 8: 47, 9: 41, 10: 36},  # noqa E501
+    30: {1: 93, 2: 86, 3: 79, 4: 73, 5: 67, 6: 61, 7: 55, 8: 50, 9: 45, 10: 40},  # noqa E501
+    33: {1: 93, 2: 87, 3: 80, 4: 74, 5: 69, 6: 63, 7: 58, 8: 53, 9: 48, 10: 43},  # noqa E501
 }
+# fmt: on
 
 # http://www.engineeringtoolbox.com/water-vapor-saturation-pressure-air-d_689.html
 TEMP_SAT_PRES_DENSITY = {
@@ -102,7 +103,7 @@ TEMP_SAT_PRES_DENSITY = {
     140: (358137, 1.91),
     160: (611728, 3.11),
     180: (990022, 4.80),
-    200: (1529627, 7.11)
+    200: (1529627, 7.11),
 }
 
 
@@ -111,33 +112,45 @@ class TestsPsychrometrics(TestCase):
 
     pressure_error = 0.5  # kPa
     total_pressure_error = 1.6  # kPa
-    total_pressure_error_altitude = 4.  # kPa
+    total_pressure_error_altitude = 4.0  # kPa
 
     def _error_compare(self, value, value_ref, max_error, mask_msg):
-        self.assertLess(abs(value - value_ref), max_error,
-                        mask_msg.format(max_error, value_ref, value))
+        self.assertLess(
+            abs(value - value_ref),
+            max_error,
+            mask_msg.format(max_error, value_ref, value),
+        )
 
     def test_press_by_altitude(self):
         """Pressure in kPa from altitude in meters."""
         from psychrochart.equations import pressure_by_altitude
 
-        errors = [pressure_by_altitude(alt)
-                  - ALTITUDE_M_PRESSURE_KPA[alt]
-                  for alt in ALTITUDE_M_PRESSURE_KPA]
+        errors = [
+            pressure_by_altitude(alt) - ALTITUDE_M_PRESSURE_KPA[alt]
+            for alt in ALTITUDE_M_PRESSURE_KPA
+        ]
         self._error_compare(
-            sum(errors), 0, self.total_pressure_error_altitude,
-            "Pressure for altitude cumulative error > {} kPa ({}) -> {}")
+            sum(errors),
+            0,
+            self.total_pressure_error_altitude,
+            "Pressure for altitude cumulative error > {0} kPa ({1}) -> {2}",
+        )
 
-        [self._error_compare(
-            pressure_by_altitude(alt),
-            ALTITUDE_M_PRESSURE_KPA[alt],
-            10 * self.pressure_error,
-            "Pressure for altitude error> {} kPa: alt={} m, est={}")
-            for alt in sorted(ALTITUDE_M_PRESSURE_KPA)]
+        [
+            self._error_compare(
+                pressure_by_altitude(alt),
+                ALTITUDE_M_PRESSURE_KPA[alt],
+                10 * self.pressure_error,
+                "Pressure for altitude error> {0} kPa: alt={1} m, est={2}",
+            )
+            for alt in sorted(ALTITUDE_M_PRESSURE_KPA)
+        ]
 
     def test_relative_humidity_from_temps(self):
         from psychrochart.equations import (
-            relative_humidity_from_temps, PRESSURE_STD_ATM_KPA)
+            relative_humidity_from_temps,
+            PRESSURE_STD_ATM_KPA,
+        )
 
         p_atm_kpa = PRESSURE_STD_ATM_KPA
 
@@ -145,48 +158,59 @@ class TestsPsychrometrics(TestCase):
             for delta_t, obj_rel_humid in data.items():
                 wet_temp_c = dry_temp_c - delta_t
                 rel_humid_calc = relative_humidity_from_temps(
-                    dry_temp_c, wet_temp_c, p_atm_kpa=p_atm_kpa)
+                    dry_temp_c, wet_temp_c, p_atm_kpa=p_atm_kpa
+                )
                 self.assertAlmostEqual(
-                    round(100 * rel_humid_calc, 1), obj_rel_humid,
-                    delta=0.65)
+                    round(100 * rel_humid_calc, 1), obj_rel_humid, delta=0.65
+                )
 
     def test_max_specific_humid(self):
         """Max Specific humidity from dry bulb temperature."""
         from psychrochart.equations import (
-            humidity_ratio, saturation_pressure_water_vapor)
+            humidity_ratio,
+            saturation_pressure_water_vapor,
+        )
 
         for t, (ps_ref, xmax_ref) in TEMP_SAT_PRESS_HUMID_RATIO.items():
             psat = saturation_pressure_water_vapor(t)
             xmax = humidity_ratio(psat)
-            # print(t, psat, ps_ref / 1000, xmax, xmax_ref)
             self.assertAlmostEqual(psat, ps_ref / 1000, delta=0.05)
             self.assertAlmostEqual(xmax, xmax_ref, delta=0.0005)
 
     def test_density_water_vapor(self):
         from psychrochart.equations import (
-            density_water_vapor, saturation_pressure_water_vapor)
+            density_water_vapor,
+            saturation_pressure_water_vapor,
+        )
 
         for dry_temp_c, (p_sat_ref, d_ref) in TEMP_SAT_PRES_DENSITY.items():
-            p_sat_ref /= 1000.  # to kPa
+            p_sat_ref /= 1000.0  # to kPa
             p_sat = saturation_pressure_water_vapor(dry_temp_c)
             # Check with 5% error at 100 ºC
             self.assertAlmostEqual(
-                p_sat, p_sat_ref,
-                delta=p_sat_ref / 20 * max(.5, dry_temp_c / 100))
+                p_sat,
+                p_sat_ref,
+                delta=p_sat_ref / 20 * max(0.5, dry_temp_c / 100),
+            )
 
             dens_kg_m3 = density_water_vapor(p_sat, dry_temp_c)
             # print('DBT {} ºC -> {:.3f} (ref: {})  - Err={} %'.format(
             #     dry_temp_c, dens_kg_m3, d_ref,
             #     round(100 * (dens_kg_m3 - d_ref) / d_ref, 1)))
             self.assertAlmostEqual(
-                dens_kg_m3, d_ref,
-                delta=max(0.005, d_ref / 20) * max(.2, dry_temp_c / 100))
+                dens_kg_m3,
+                d_ref,
+                delta=max(0.005, d_ref / 20) * max(0.2, dry_temp_c / 100),
+            )
 
     def test_enthalpy_moist_air(self):
         """Check the enthalpy of humid air."""
         from psychrochart.equations import (
-            PRESSURE_STD_ATM_KPA, saturation_pressure_water_vapor,
-            humidity_ratio, enthalpy_moist_air)
+            PRESSURE_STD_ATM_KPA,
+            saturation_pressure_water_vapor,
+            humidity_ratio,
+            enthalpy_moist_air,
+        )
 
         # From http://www.engineeringtoolbox.com/enthalpy-moist-air-d_683.html
         # Check the enthalpy of humid air at 25ºC with specific
@@ -216,8 +240,10 @@ class TestsPsychrometrics(TestCase):
         # self.assertAlmostEqual(1 / vol_m3_kg, d_ref, delta=1)
 
         from psychrochart.equations import (
-            PRESSURE_STD_ATM_KPA, saturation_pressure_water_vapor,
-            specific_volume)
+            PRESSURE_STD_ATM_KPA,
+            saturation_pressure_water_vapor,
+            specific_volume,
+        )
 
         press = PRESSURE_STD_ATM_KPA
         for t, (ps_ref, dens_ref) in TEMP_PRESS_PA_DENS_G_KG.items():
@@ -227,7 +253,9 @@ class TestsPsychrometrics(TestCase):
             # xmax = humidity_ratio(psat)
             vol_psat = specific_volume(t, psat, p_atm_kpa=press)
             vol_p0 = specific_volume(t, 0, p_atm_kpa=press)
-            print('DEB', t, dens_ref, vol_psat, vol_p0, 1/vol_psat, 1/vol_p0)
+            print(
+                "DEB", t, dens_ref, vol_psat, vol_p0, 1 / vol_psat, 1 / vol_p0
+            )
             dens_kg_m3 = 1 / vol_psat - 1 / vol_p0
             print(dens_kg_m3)
 
@@ -240,57 +268,75 @@ class TestsPsychrometrics(TestCase):
         from psychrochart.equations import saturation_pressure_water_vapor
 
         for mode in [1, 2, 3]:
-            errors = [saturation_pressure_water_vapor(t, mode=mode)
-                      - DRY_TEMP_PSAT_KPA[t]
-                      for t in sorted(DRY_TEMP_PSAT_KPA)]
+            errors = [
+                saturation_pressure_water_vapor(t, mode=mode)
+                - DRY_TEMP_PSAT_KPA[t]
+                for t in sorted(DRY_TEMP_PSAT_KPA)
+            ]
 
             self._error_compare(
-                sum(errors), 0, self.total_pressure_error,
-                "Saturation Pressure error > {} kPa ({}) -> {}")
+                sum(errors),
+                0,
+                self.total_pressure_error,
+                "Saturation Pressure error > {0} kPa ({1}) -> {2}",
+            )
 
     def test_press_sat_mode_1(self):
         """Saturation pressure in kPa from dry bulb temperature. Mode 1."""
         from psychrochart.equations import saturation_pressure_water_vapor
 
         mode = 1
-        [self._error_compare(
-            saturation_pressure_water_vapor(t, mode=mode),
-            DRY_TEMP_PSAT_KPA[t], self.pressure_error * max(.8, t / 50),
-            "M1 - Saturation Pressure error > {} kPa: T={}, est={}")
-            for t in sorted(DRY_TEMP_PSAT_KPA)]
+        [
+            self._error_compare(
+                saturation_pressure_water_vapor(t, mode=mode),
+                DRY_TEMP_PSAT_KPA[t],
+                self.pressure_error * max(0.8, t / 50),
+                "M1 - Saturation Pressure error > {} kPa: T={}, est={}",
+            )
+            for t in sorted(DRY_TEMP_PSAT_KPA)
+        ]
 
     def test_press_sat_mode_2(self):
         """Saturation pressure in kPa from dry bulb temperature. Mode 2."""
         from psychrochart.equations import saturation_pressure_water_vapor
 
         mode = 2
-        [self._error_compare(
-            saturation_pressure_water_vapor(t, mode=mode),
-            DRY_TEMP_PSAT_KPA[t], self.pressure_error * max(.8, t / 50),
-            "M2 - Saturation Pressure error > {} kPa: T={}, est={}")
-            for t in sorted(DRY_TEMP_PSAT_KPA)]
+        [
+            self._error_compare(
+                saturation_pressure_water_vapor(t, mode=mode),
+                DRY_TEMP_PSAT_KPA[t],
+                self.pressure_error * max(0.8, t / 50),
+                "M2 - Saturation Pressure error > {} kPa: T={}, est={}",
+            )
+            for t in sorted(DRY_TEMP_PSAT_KPA)
+        ]
 
     def test_press_sat_mode_3(self):
         """Saturation pressure in kPa from dry bulb temperature. Mode 3."""
         from psychrochart.equations import saturation_pressure_water_vapor
 
         mode = 3
-        [self._error_compare(
-            saturation_pressure_water_vapor(t, mode=mode),
-            DRY_TEMP_PSAT_KPA[t], self.pressure_error * max(.8, t / 50),
-            "M3 - Saturation Pressure error > {} kPa: T={}, est={}")
-            for t in sorted(DRY_TEMP_PSAT_KPA)]
+        [
+            self._error_compare(
+                saturation_pressure_water_vapor(t, mode=mode),
+                DRY_TEMP_PSAT_KPA[t],
+                self.pressure_error * max(0.8, t / 50),
+                "M3 - Saturation Pressure error > {} kPa: T={}, est={}",
+            )
+            for t in sorted(DRY_TEMP_PSAT_KPA)
+        ]
 
     def test_dew_point_temperature(self):
         """Dew point temperature testing."""
         from psychrochart.equations import (
-            saturation_pressure_water_vapor, dew_point_temperature)
+            saturation_pressure_water_vapor,
+            dew_point_temperature,
+        )
         from psychrochart.util import f_range
 
         temps = f_range(-20, 60, 1)
         for t in temps:
             p_sat = saturation_pressure_water_vapor(t)
-            # w_sat = humidity_ratio(p_sat, p_atm_kpa=p_atm)
             temp_dp_sat = dew_point_temperature(p_sat)
             if temp_dp_sat < 0:
                 self.assertAlmostEqual(temp_dp_sat, t, delta=3)
@@ -300,8 +346,10 @@ class TestsPsychrometrics(TestCase):
     def test_wet_bulb_temperature(self):
         """Wet bulb temperature from dry bulb temp and relative humidity."""
         from psychrochart.equations import (
-            wet_bulb_temperature, relative_humidity_from_temps,
-            PRESSURE_STD_ATM_KPA)
+            wet_bulb_temperature,
+            relative_humidity_from_temps,
+            PRESSURE_STD_ATM_KPA,
+        )
         from psychrochart.util import f_range
 
         precision = 0.00001
@@ -310,24 +358,32 @@ class TestsPsychrometrics(TestCase):
         for dry_temp_c in f_range(-10, 60, 2.5):
             for relative_humid in f_range(0.05, 1.0001, 0.05):
                 wet_temp_c = wet_bulb_temperature(
-                    dry_temp_c, relative_humid,
-                    p_atm_kpa=p_atm, precision=precision)
+                    dry_temp_c,
+                    relative_humid,
+                    p_atm_kpa=p_atm,
+                    precision=precision,
+                )
                 rh_calc = relative_humidity_from_temps(
-                    dry_temp_c, wet_temp_c, p_atm_kpa=p_atm)
+                    dry_temp_c, wet_temp_c, p_atm_kpa=p_atm
+                )
                 # print('wet_temp_c(dbt, rh): {:.3f} ºC ({:.1f} ºC, {:.1f} %)'
                 #       .format(wet_temp_c, dry_temp_c, relative_humid * 100))
                 self.assertAlmostEqual(relative_humid, rh_calc, delta=0.01)
 
         precision = 0.00001
-        p_atm = PRESSURE_STD_ATM_KPA * .75
+        p_atm = PRESSURE_STD_ATM_KPA * 0.75
 
         for dry_temp_c in f_range(-5, 50, 5):
             for relative_humid in f_range(0.05, 1.0001, 0.1):
                 wet_temp_c = wet_bulb_temperature(
-                    dry_temp_c, relative_humid,
-                    p_atm_kpa=p_atm, precision=precision)
+                    dry_temp_c,
+                    relative_humid,
+                    p_atm_kpa=p_atm,
+                    precision=precision,
+                )
                 rh_calc = relative_humidity_from_temps(
-                    dry_temp_c, wet_temp_c, p_atm_kpa=p_atm)
+                    dry_temp_c, wet_temp_c, p_atm_kpa=p_atm
+                )
                 # print('wet_temp_c(dbt, rh): {:.3f} ºC ({:.1f} ºC, {:.1f} %)'
                 #       .format(wet_temp_c, dry_temp_c, relative_humid * 100))
                 self.assertAlmostEqual(relative_humid, rh_calc, delta=0.01)
@@ -335,25 +391,32 @@ class TestsPsychrometrics(TestCase):
     def test_wet_bulb_temperature_empiric(self):
         """Empiric wet bulb temperature from dry bulb and relative humidity."""
         from psychrochart.equations import (
-            wet_bulb_temperature_empiric, wet_bulb_temperature)
+            wet_bulb_temperature_empiric,
+            wet_bulb_temperature,
+        )
         from psychrochart.util import f_range
 
         for dry_temp_c in f_range(-20, 50, 2.5):
             for relative_humid in f_range(0.05, 1.0001, 0.05):
                 wet_temp_c_ref = wet_bulb_temperature(
-                    dry_temp_c, relative_humid)
+                    dry_temp_c, relative_humid
+                )
                 wet_temp_c = wet_bulb_temperature_empiric(
-                    dry_temp_c, relative_humid)
+                    dry_temp_c, relative_humid
+                )
                 if -2.33 * dry_temp_c + 28.33 < relative_humid:
                     if abs(wet_temp_c - wet_temp_c_ref) > 1:
-                        print('DT: {:.2f}, HR: {:.2f} => WT: [Aprox: {:.2f}, '
-                              'Iter: {:.2f} -> ∆: {:.2f}]'.format(
-                                dry_temp_c, relative_humid, wet_temp_c,
-                                wet_temp_c_ref,
-                                abs(wet_temp_c - wet_temp_c_ref)))
+                        print(
+                            f"DT: {dry_temp_c:.2f}, HR: {relative_humid:.2f} "
+                            f"=> WT: [Aprox: {wet_temp_c:.2f}, "
+                            f"in iter: {wet_temp_c_ref:.2f} "
+                            f"-> ∆: {abs(wet_temp_c - wet_temp_c_ref):.2f}]"
+                        )
                     assert abs(wet_temp_c - wet_temp_c_ref) < 1.5
                 else:
-                    print('Difference between methods: {:.2f} vs ref={:.2f}'
-                          .format(wet_temp_c, wet_temp_c_ref))
+                    print(
+                        f"Difference between methods: {wet_temp_c:.2f} vs "
+                        f"ref={wet_temp_c_ref:.2f}"
+                    )
                     # out of range
-                    assert abs(wet_temp_c - wet_temp_c_ref) > 0.
+                    assert abs(wet_temp_c - wet_temp_c_ref) > 0.0

--- a/tests/test_psychrometrics.py
+++ b/tests/test_psychrometrics.py
@@ -230,39 +230,6 @@ class TestsPsychrometrics(TestCase):
         # self.assertEqual(round(h_a, 2), 25.15)
         # self.assertEqual(round(h_v, 1), 0.93 + 50.77)
 
-    def test_density_at_saturation(self):
-        """Density of saturated humid air from dry bulb temperature."""
-        # TODO finish test specific_volume
-
-        # vol_m3_kg = specific_volume(
-        #     dry_temp_c, p_sat, p_atm_kpa=PRESSURE_STD_ATM_KPA)
-        # print(dry_temp_c, p_sat, p_sat_ref, vol_m3_kg, 1/vol_m3_kg, d_ref)
-        # self.assertAlmostEqual(1 / vol_m3_kg, d_ref, delta=1)
-
-        from psychrochart.equations import (
-            PRESSURE_STD_ATM_KPA,
-            saturation_pressure_water_vapor,
-            specific_volume,
-        )
-
-        press = PRESSURE_STD_ATM_KPA
-        for t, (ps_ref, dens_ref) in TEMP_PRESS_PA_DENS_G_KG.items():
-            # dens_ref_kg_m3 = dens_ref / 1000.
-
-            psat = saturation_pressure_water_vapor(t, mode=1)
-            # xmax = humidity_ratio(psat)
-            vol_psat = specific_volume(t, psat, p_atm_kpa=press)
-            vol_p0 = specific_volume(t, 0, p_atm_kpa=press)
-            print(
-                "DEB", t, dens_ref, vol_psat, vol_p0, 1 / vol_psat, 1 / vol_p0
-            )
-            dens_kg_m3 = 1 / vol_psat - 1 / vol_p0
-            print(dens_kg_m3)
-
-            self.assertAlmostEqual(psat, ps_ref / 1000, delta=27)
-            # self.assertAlmostEqual(psat, ps_ref / 1000, delta=0.05)
-            # self.assertAlmostEqual(xmax, xmax_ref, delta=0.0005)
-
     def test_press_sat_abs_error(self):
         """Saturation pressure in kPa from dry bulb temperature. Sum error."""
         from psychrochart.equations import saturation_pressure_water_vapor

--- a/tests/test_reuse_chart.py
+++ b/tests/test_reuse_chart.py
@@ -130,16 +130,14 @@ def _add_points(chart, with_connectors=True, path_save=None):
                 },
             },
         ]
-
-        points_plot = chart.plot_points_dbt_rh(points, connectors)
+        chart.plot_points_dbt_rh(points, connectors)
     else:
         points = {
             "exterior": (31.06, 32.9),
             "exterior_estimated": (36.7, 25.0),
             "interior": (29.42, 52.34),
         }
-        points_plot = chart.plot_points_dbt_rh(points)
-    print("Points in chart: %s" % points_plot)
+        chart.plot_points_dbt_rh(points)
     # Save to disk
     if path_save is not None:
         path_svg = os.path.join(basedir, path_save)
@@ -164,12 +162,10 @@ class TestsPsychroReuse(TestCase):
 
     def test_reuse_psychrochart(self):
         """Customize a chart with some additions"""
-        print("make_charts(with_reuse=True)")
         _make_charts(with_reuse=True)
 
     def test_no_reuse_psychrochart(self):
         """Customize a chart with some additions"""
-        print("make_charts(with_reuse=False)")
         _make_charts(with_reuse=False)
 
     def test_redraw_psychrochart(self):

--- a/tests/test_reuse_chart.py
+++ b/tests/test_reuse_chart.py
@@ -9,39 +9,41 @@ from unittest import TestCase
 from psychrochart.agg import PsychroChart
 from psychrochart.util import timeit
 
-
-basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'charts')
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "charts")
 os.makedirs(basedir, exist_ok=True)
 
 
-@timeit('make_chart')
+@timeit("make_chart")
 def _make_chart(path_save=None):
     chart = PsychroChart("minimal")
     # Zones:
     zones_conf = {
-        "zones":
-            [
-                {
-                    "zone_type": "dbt-rh",
-                    "style": {"edgecolor": [1.0, 0.749, 0.0, 0.8],
-                              "facecolor": [1.0, 0.749, 0.0, 0.2],
-                              "linewidth": 2,
-                              "linestyle": "--"},
-                    "points_x": [23, 28],
-                    "points_y": [40, 60],
-                    "label": "Summer"
+        "zones": [
+            {
+                "zone_type": "dbt-rh",
+                "style": {
+                    "edgecolor": [1.0, 0.749, 0.0, 0.8],
+                    "facecolor": [1.0, 0.749, 0.0, 0.2],
+                    "linewidth": 2,
+                    "linestyle": "--",
                 },
-                {
-                    "zone_type": "dbt-rh",
-                    "style": {"edgecolor": [0.498, 0.624, 0.8],
-                              "facecolor": [0.498, 0.624, 1.0, 0.2],
-                              "linewidth": 2,
-                              "linestyle": "--"},
-                    "points_x": [18, 23],
-                    "points_y": [35, 55],
-                    "label": "Winter"
-                }
-            ]
+                "points_x": [23, 28],
+                "points_y": [40, 60],
+                "label": "Summer",
+            },
+            {
+                "zone_type": "dbt-rh",
+                "style": {
+                    "edgecolor": [0.498, 0.624, 0.8],
+                    "facecolor": [0.498, 0.624, 1.0, 0.2],
+                    "linewidth": 2,
+                    "linestyle": "--",
+                },
+                "points_x": [18, 23],
+                "points_y": [35, 55],
+                "label": "Winter",
+            },
+        ]
     }
     chart.append_zones(zones_conf)
     # Plotting
@@ -49,74 +51,112 @@ def _make_chart(path_save=None):
     # Vertical lines
     t_min, t_opt, t_max = 16, 23, 30
     chart.plot_vertical_dry_bulb_temp_line(
-        t_min, {"color": [0.0, 0.125, 0.376], "lw": 2, "ls": ':'},
-        '  TOO COLD ({}°C)'.format(t_min), ha='left', loc=0., fontsize=14)
+        t_min,
+        {"color": [0.0, 0.125, 0.376], "lw": 2, "ls": ":"},
+        f"  TOO COLD ({t_min}°C)",
+        ha="left",
+        loc=0.0,
+        fontsize=14,
+    )
     chart.plot_vertical_dry_bulb_temp_line(
-        t_opt, {"color": [0.475, 0.612, 0.075], "lw": 2, "ls": ':'})
+        t_opt, {"color": [0.475, 0.612, 0.075], "lw": 2, "ls": ":"}
+    )
     chart.plot_vertical_dry_bulb_temp_line(
-        t_max, {"color": [1.0, 0.0, 0.247], "lw": 2, "ls": ':'},
-        'TOO HOT ({}°C)  '.format(t_max), ha='right', loc=1,
-        reverse=True, fontsize=14)
+        t_max,
+        {"color": [1.0, 0.0, 0.247], "lw": 2, "ls": ":"},
+        f"TOO HOT ({t_max}°C)  ",
+        ha="right",
+        loc=1,
+        reverse=True,
+        fontsize=14,
+    )
     # Save to disk the base chart
     if path_save is not None:
-        path_svg = os.path.join(
-            basedir, path_save)
+        path_svg = os.path.join(basedir, path_save)
         chart.save(path_svg)
     return chart
 
 
-@timeit('add_points')
+@timeit("add_points")
 def _add_points(chart, with_connectors=True, path_save=None):
     if with_connectors:
         # Append points and connectors
-        points = {'exterior': {'label': 'Exterior',
-                               'style': {
-                                   'color': [0.855, 0.004, 0.278, 0.8],
-                                   'marker': 'X', 'markersize': 15},
-                               'xy': (31.06, 32.9)},
-                  'exterior_estimated': {
-                      'label': 'Estimated (Weather service)',
-                      'style': {'color': [0.573, 0.106, 0.318, 0.5],
-                                'marker': 'x', 'markersize': 10},
-                      'xy': (36.7, 25.0)},
-                  'interior': {'label': 'Interior',
-                               'style': {
-                                   'color': [0.592, 0.745, 0.051, 0.9],
-                                   'marker': 'o', 'markersize': 30},
-                               'xy': (29.42, 52.34)}}
-        connectors = [{'start': 'exterior',
-                       'end': 'exterior_estimated',
-                       'style': {'color': [0.573, 0.106, 0.318, 0.7],
-                                 "linewidth": 2, "linestyle": "-."}},
-                      {'start': 'exterior',
-                       'end': 'interior',
-                       'style': {'color': [0.855, 0.145, 0.114, 0.8],
-                                 "linewidth": 2, "linestyle": ":"}}]
+        points = {
+            "exterior": {
+                "label": "Exterior",
+                "style": {
+                    "color": [0.855, 0.004, 0.278, 0.8],
+                    "marker": "X",
+                    "markersize": 15,
+                },
+                "xy": (31.06, 32.9),
+            },
+            "exterior_estimated": {
+                "label": "Estimated (Weather service)",
+                "style": {
+                    "color": [0.573, 0.106, 0.318, 0.5],
+                    "marker": "x",
+                    "markersize": 10,
+                },
+                "xy": (36.7, 25.0),
+            },
+            "interior": {
+                "label": "Interior",
+                "style": {
+                    "color": [0.592, 0.745, 0.051, 0.9],
+                    "marker": "o",
+                    "markersize": 30,
+                },
+                "xy": (29.42, 52.34),
+            },
+        }
+        connectors = [
+            {
+                "start": "exterior",
+                "end": "exterior_estimated",
+                "style": {
+                    "color": [0.573, 0.106, 0.318, 0.7],
+                    "linewidth": 2,
+                    "linestyle": "-.",
+                },
+            },
+            {
+                "start": "exterior",
+                "end": "interior",
+                "style": {
+                    "color": [0.855, 0.145, 0.114, 0.8],
+                    "linewidth": 2,
+                    "linestyle": ":",
+                },
+            },
+        ]
 
         points_plot = chart.plot_points_dbt_rh(points, connectors)
     else:
-        points = {'exterior': (31.06, 32.9),
-                  'exterior_estimated': (36.7, 25.0),
-                  'interior': (29.42, 52.34)}
+        points = {
+            "exterior": (31.06, 32.9),
+            "exterior_estimated": (36.7, 25.0),
+            "interior": (29.42, 52.34),
+        }
         points_plot = chart.plot_points_dbt_rh(points)
-    print('Points in chart: %s' % points_plot)
+    print("Points in chart: %s" % points_plot)
     # Save to disk
     if path_save is not None:
         path_svg = os.path.join(basedir, path_save)
         chart.save(path_svg)
 
 
-@timeit('MAKE_CHARTS')
+@timeit("MAKE_CHARTS")
 def _make_charts(with_reuse=False):
-    name = 'test_reuse_chart_' if with_reuse else 'test_noreuse_chart_'
+    name = "test_reuse_chart_" if with_reuse else "test_noreuse_chart_"
     chart = _make_chart()
-    _add_points(chart, True, '{}_1.svg'.format(name))
+    _add_points(chart, True, f"{name}_1.svg")
 
     if with_reuse:
         chart.remove_annotations()
     else:
         chart = _make_chart()
-    _add_points(chart, False, '{}_2.svg'.format(name))
+    _add_points(chart, False, f"{name}_2.svg")
 
 
 class TestsPsychroReuse(TestCase):
@@ -124,21 +164,20 @@ class TestsPsychroReuse(TestCase):
 
     def test_reuse_psychrochart(self):
         """Customize a chart with some additions"""
-        print('make_charts(with_reuse=True)')
+        print("make_charts(with_reuse=True)")
         _make_charts(with_reuse=True)
 
     def test_no_reuse_psychrochart(self):
         """Customize a chart with some additions"""
-        print('make_charts(with_reuse=False)')
+        print("make_charts(with_reuse=False)")
         _make_charts(with_reuse=False)
 
     def test_redraw_psychrochart(self):
         """Test the workflow to redraw a chart."""
         chart = _make_chart()
         chart.plot_legend()
-        _add_points(chart, True, 'test_redraw_chart_1.svg')
+        _add_points(chart, True, "test_redraw_chart_1.svg")
         chart.close_fig()
 
-        # chart.plot_legend()
-        _add_points(chart, False, 'test_redraw_chart_2.svg')
+        _add_points(chart, False, "test_redraw_chart_2.svg")
         chart.close_fig()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,9 +7,8 @@ import json
 import os
 from unittest import TestCase
 
-
 basedir = os.path.dirname(os.path.abspath(__file__))
-PATH_CONFIG_UPDATE = os.path.join(basedir, 'test_chart_config_update.json')
+PATH_CONFIG_UPDATE = os.path.join(basedir, "test_chart_config_update.json")
 
 
 class TestsPsychroUtils(TestCase):
@@ -29,20 +28,17 @@ class TestsPsychroUtils(TestCase):
         self.assertEqual(config_2, config_3)
 
         # Test update config:
-        config_custom = load_config(styles=PATH_CONFIG_UPDATE,
-                                    verbose=True)
+        config_custom = load_config(styles=PATH_CONFIG_UPDATE, verbose=True)
         self.assertNotEqual(default_config, config_custom)
-        self.assertIn('constant_h', config_custom)
-        self.assertIn('constant_v', config_custom)
-        self.assertNotIn('test_fake_param', config_custom)
+        self.assertIn("constant_h", config_custom)
+        self.assertIn("constant_v", config_custom)
+        self.assertNotIn("test_fake_param", config_custom)
 
         # Test config styles:
-        default_config_s = load_config(
-            styles="default", verbose=True)
+        default_config_s = load_config(styles="default", verbose=True)
         self.assertEqual(default_config, default_config_s)
 
-        ashrae_config_s = load_config(
-            styles="ashrae", verbose=True)
+        ashrae_config_s = load_config(styles="ashrae", verbose=True)
         self.assertNotEqual(default_config, ashrae_config_s)
 
 
@@ -52,7 +48,7 @@ class TestsCLI(TestCase):
     def test_cli_main(self):
         """Unit test for the CLI entry point."""
         # noinspection PyUnresolvedReferences
-        import psychrochart.agg
+        import psychrochart.agg  # noqa F401
         from psychrochart.__main__ import main
 
         main()
@@ -66,8 +62,10 @@ class TestsColorUtils(TestCase):
         from psychrochart.util import mod_color
 
         def _to_8bit_color(color):
-            return tuple([int(round(255 * c)) if i < 3 else c
-                          for i, c in enumerate(color)])
+            return tuple(
+                int(round(255 * c)) if i < 3 else c
+                for i, c in enumerate(color)
+            )
 
         color_base = [0.475, 0.612, 0.075]
         self.assertEqual(_to_8bit_color(color_base), (121, 156, 19))
@@ -78,5 +76,5 @@ class TestsColorUtils(TestCase):
         color_dark_40 = mod_color(color_base, -40)
         self.assertEqual(_to_8bit_color(color_dark_40), (73, 94, 11))
 
-        color_alpha_08 = mod_color(color_base, .8)
+        color_alpha_08 = mod_color(color_base, 0.8)
         self.assertEqual(_to_8bit_color(color_alpha_08), (121, 156, 19, 0.8))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,17 +28,17 @@ class TestsPsychroUtils(TestCase):
         self.assertEqual(config_2, config_3)
 
         # Test update config:
-        config_custom = load_config(styles=PATH_CONFIG_UPDATE, verbose=True)
+        config_custom = load_config(styles=PATH_CONFIG_UPDATE)
         self.assertNotEqual(default_config, config_custom)
         self.assertIn("constant_h", config_custom)
         self.assertIn("constant_v", config_custom)
         self.assertNotIn("test_fake_param", config_custom)
 
         # Test config styles:
-        default_config_s = load_config(styles="default", verbose=True)
+        default_config_s = load_config(styles="default")
         self.assertEqual(default_config, default_config_s)
 
-        ashrae_config_s = load_config(styles="ashrae", verbose=True)
+        ashrae_config_s = load_config(styles="ashrae")
         self.assertNotEqual(default_config, ashrae_config_s)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist=py36,py37,py38,flake8,typing
+envlist=py36,py37,flake8,typing
 
 [tox:travis]
 3.6 = py36
 3.7 = py37
-3.8 = py38
 
 [testenv]
 deps=pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist=py35,py36,flake8,typing
+envlist=py36,py37,py38,flake8,typing
 
 [tox:travis]
-3.5 = py35
 3.6 = py36
+3.7 = py37
+3.8 = py38
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
As this project was unattended from my side for too much time, as the first step towards an increase in features and more, this PR only addresses aesthetic changes in the code, updating it to comply with the last de-facto standards in the python 3 community.

In that direction, changes here are:
* Require at least python 3.6
* Bump minimal version of matplotlib and add scipy
* Code massive re-formatting: apply **[`black`](https://black.readthedocs.io/en/stable/)**, sort all imports and pass stricter `flake8` lint controls, use _f-strings_ :)

The minor version is bumped to 2.2.7, but no real changes are done in the logic.