### PR TITLE
fixing chart setup error with gca() call for recent Matplotlib versions

### DIFF
--- a/psychrochart/chart.py
+++ b/psychrochart/chart.py
@@ -530,7 +530,7 @@ class PsychroChart:
         self._fig = figure.Figure(figsize=figsize, dpi=150, frameon=False)
         self._canvas = FigureCanvas(self.figure)
         if ax is None:
-            ax = self.figure.gca(position=position)
+            ax = self.figure.add_subplot(position=position)
         ax.yaxis.tick_right()
         ax.yaxis.set_label_position("right")
         ax.set_xlim(self.dbt_min, self.dbt_max)


### PR DESCRIPTION
Since adding parameters directly to Figure.gca() function was deprecated in Matplotlib 3.4, I made a fix that seems to solve the issue for newer versions of Matplotlib.

solution based on this thread:
https://stackoverflow.com/questions/67095247/gca-and-latest-version-of-matplotlib