### PR TITLE
✨ Add zone kind 'dbt-wmax' with vapour content limit + bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✨ Add new kind of overlay **zone 'dbt-wmax'**, to define chart areas delimited between db-temps and absolute humidity values, solving #28
 - 🐛 Enable zones defined by 2 points (assume a rectangle defined by left-bottom/right-top coords)
 - 🐛 Fix logic for plot regeneration, to plot again if config changes _AFTER_ plotting the chart
+- 🐛 Fix ZoneStyle definition when linewidth is 0 and linestyle remains the default (passing inconsistent params to matplotlib)
 
 ## [0.9.0] - ✨ More kinds of chart zones + CSS for SVG styling - 2023-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - ✨ Add zone kind 'dbt-wmax' with vapour content limit - 2023-06-13
+
+##### Changes
+
+- ✨ Add new kind of overlay **zone 'dbt-wmax'**, to define chart areas delimited between db-temps and absolute humidity values, solving #28
+- 🐛 Enable zones defined by 2 points (assume a rectangle defined by left-bottom/right-top coords)
+- 🐛 Fix logic for plot regeneration, to plot again if config changes _AFTER_ plotting the chart
+
 ## [0.9.0] - ✨ More kinds of chart zones + CSS for SVG styling - 2023-06-12
 
 Define new enclosed areas in chart between constant RH lines and constant volume or enthalpy values,

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ pip install psychrochart
 
 ## Features
 
-- **SI** units (with temperatures in celsius for better readability).
-- Easy style customization based on [**pydantic**](https://docs.pydantic.dev/latest/) models and config presets for full customization of colors, line styles, line widths, etc..
+- **SI** units (with temperatures in celsius for better readability), with _partial_ compatibility with IP system (imperial units)
+- Easy style customization based on [**pydantic**](https://docs.pydantic.dev/latest/) models and config presets for full customization of **chart limits**, included lines and labels, colors, line styles, line widths, etc..
 - Psychrometric charts within temperature and humidity ratio ranges, for any pressure\*, with:
   - **Saturation line**
   - **Constant RH lines**
@@ -41,10 +41,16 @@ pip install psychrochart
   - **Constant specific volume lines**
   - **Constant dry-bulb temperature lines** (internal orthogonal grid, vertical)
   - **Constant humidity ratio lines** (internal orthogonal grid, horizontal)
-- Plot legend for each family of lines
+- Plot legend for each family of lines, labeled zones and annotations
 - Specify labels for each family of lines
-- **Overlay points, zones, convex hulls, and arrows**
-- **Export SVG, PNG files**
+- Overlay points, arrows, **data-series** (numpy arrays or pandas series), and convex hulls around points
+- Define multiple kinds of **zones limited by psychrometric values**:
+  - 'dbt-rh' for areas between dry-bulb temperature and relative humidity values,
+  - 'enthalpy-rh' for areas between constant enthalpy and relative humidity values
+  - 'volume-rh' for areas between constant volume and relative humidity values
+  - 'dbt-wmax' for an area between dry-bulb temperature and water vapor content values (:= a rectangle cut by the saturation line),
+  - 'xy-points' to define arbitrary closed paths in plot coordinates (dbt, abs humidity)
+- **Export as SVG, PNG files**, or generate dynamic SVGs with extra CSS and <defs> with `chart.make_svg(...)`
 
 > NOTE: The ranges of temperature, humidity and pressure where this library should provide good results are within the normal environments for people to live in.
 >

--- a/psychrochart/chart.py
+++ b/psychrochart/chart.py
@@ -128,8 +128,7 @@ class PsychroChart(PsychroChartModel):
     @property
     def axes(self) -> Axes:
         """Return the Axes object plotting the chart if necessary."""
-        self.process_chart()
-        if not self.rendered:
+        if not self.rendered or self.config.has_changed:
             self.plot()
         assert isinstance(self._axes, Axes)
         return self._axes

--- a/psychrochart/chart.py
+++ b/psychrochart/chart.py
@@ -421,7 +421,7 @@ class PsychroChart(PsychroChartModel):
         svg_definitions: str | None = None,
         **params,
     ) -> str:
-        """Generate chart as SVG and return as text."""
+        """Generate chart as SVG, with optional styling, and return as text."""
         svg_io = StringIO()
         self.save(svg_io, canvas_cls=FigureCanvasSVG, **params)
         svg_io.seek(0)

--- a/psychrochart/models/annots.py
+++ b/psychrochart/models/annots.py
@@ -23,7 +23,6 @@ class ChartPoint(BaseModel):
 class ChartSeries(BaseModel):
     """Input model for data-series point array annotation."""
 
-    # TODO fusion with PsychroCurve, + pandas ready
     x_data: np.ndarray
     y_data: np.ndarray
     style: dict[str, Any] = Field(default_factory=dict)

--- a/psychrochart/models/config.py
+++ b/psychrochart/models/config.py
@@ -39,7 +39,9 @@ _DEFAULT_STYLE_HUMID = CurveStyle(
     color=[0.0, 0.125, 0.376], linewidth=0.75, linestyle=":"
 )
 
-ZoneKind = Literal["dbt-rh", "xy-points", "enthalpy-rh", "volume-rh"]
+ZoneKind = Literal[
+    "dbt-rh", "xy-points", "enthalpy-rh", "volume-rh", "dbt-wmax"
+]
 
 
 class ChartFigure(BaseConfig):

--- a/psychrochart/models/styles.py
+++ b/psychrochart/models/styles.py
@@ -67,5 +67,8 @@ class ZoneStyle(BaseConfig):
         return parse_color(v)
 
     @root_validator(pre=True)
-    def _remove_aliases(cls, values):
+    def _remove_aliases_and_fix_defaults(cls, values):
+        if values.get("linewidth", 2) == 0:
+            # avoid matplotlib error with inconsistent line parameters
+            values["linestyle"] = "-"
         return reduce_field_abrs(values)

--- a/psychrochart/plot_logic.py
+++ b/psychrochart/plot_logic.py
@@ -135,15 +135,25 @@ def plot_curve(
         return {}
 
     if isinstance(curve.style, ZoneStyle):
-        assert len(curve.y_data) > 2
-        verts = list(zip(curve.x_data, curve.y_data))
-        codes = (
-            [Path.MOVETO]
-            + [Path.LINETO] * (len(curve.y_data) - 2)
-            + [Path.CLOSEPOLY]
-        )
-        path = Path(verts, codes)
-        patch = patches.PathPatch(path, **curve.style.dict())
+        if len(curve.y_data) == 2:  # draw a rectangle!
+            patch = patches.Rectangle(
+                (curve.x_data[0], curve.y_data[0]),
+                width=curve.x_data[1] - curve.x_data[0],
+                height=curve.y_data[1] - curve.y_data[0],
+                **curve.style.dict(),
+            )
+            bbox_p = patch.get_extents()
+        else:
+            assert len(curve.y_data) > 2
+            verts = list(zip(curve.x_data, curve.y_data))
+            codes = (
+                [Path.MOVETO]
+                + [Path.LINETO] * (len(curve.y_data) - 2)
+                + [Path.CLOSEPOLY]
+            )
+            path = Path(verts, codes)
+            patch = patches.PathPatch(path, **curve.style.dict())
+            bbox_p = path.get_extents()
         ax.add_patch(patch)
         gid_zone = make_item_gid(
             "zone",
@@ -156,7 +166,6 @@ def plot_curve(
             artists,
         )
         if curve.label is not None:
-            bbox_p = path.get_extents()
             text_x = 0.5 * (bbox_p.x0 + bbox_p.x1)
             text_y = 0.5 * (bbox_p.y0 + bbox_p.y1)
             style_params = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ log_date_format = "%Y-%m-%d %H:%M:%S"
 
 [tool.poetry]
 name = "psychrochart"
-version = "0.9.0"
+version = "0.9.1"
 description = "A python 3 library to make psychrometric charts and overlay information on them"
 authors = ["Eugenio Panadero <eugenio.panadero@gmail.com>"]
 packages = [

--- a/tests/test_chart_zones.py
+++ b/tests/test_chart_zones.py
@@ -252,12 +252,7 @@ def test_sat_no_sat_zones():
             zone_type="dbt-wmax",
             points_x=[chart.config.dbt_min, chart.config.dbt_max],
             points_y=[chart.config.w_min, chart.config.w_max],
-            style=ZoneStyle(
-                edgecolor="none",
-                facecolor="#C8E44088",
-                linewidth=0,
-                linestyle="-",
-            ),
+            style=ZoneStyle(edgecolor="k", facecolor="#e4a039", linewidth=0),
         )
     )
     chart.plot_over_saturated_zone(color_fill="#5A90E4")


### PR DESCRIPTION
closes #28 

### Changes

- ✨ Add new kind of overlay **zone 'dbt-wmax'**, to define chart areas delimited between db-temps and absolute humidity values, solving #28
- 🐛 Enable zones defined by 2 points (assume a rectangle defined by left-bottom/right-top coords)
- 🐛 Fix logic for plot regeneration, to plot again if config changes _AFTER_ plotting the chart
- 🐛 Fix ZoneStyle definition when linewidth is 0 and linestyle remains the default (passing inconsistent params to matplotlib)
