### PR TITLE
📦️ Remove `scipy` dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: ruff-format
 
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
-    rev: "v4.5.0"
+    rev: "v4.6.0"
     hooks:
       - id: "end-of-file-fixer"
       - id: "trailing-whitespace"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 📦️ Remove scipy dependency - 2024-04-08
+
+##### Changes
+
+- ⚡️ Use simple **1D interpolator** to project lines, instead of `scipy.interpolate.interp1d`
+- ✅ Add tests for convex hulls of given points
+- ⚡️ Use simple **convex hull algorithm**, to compute zones to group annotated points, instead of using `scipy.spatial.ConvexHull`
+- 📦️ Bump version, removing `scipy` dependency
+
 ## [0.10.0] - 📦 Migrate to pydantic v2 - 2024-04-07
 
 Move to recent versions of `pydantic`, and also upgrade internal _linters_, moving to `ruff-format`

--- a/poetry.lock
+++ b/poetry.lock
@@ -929,48 +929,6 @@ files = [
 ]
 
 [[package]]
-name = "scipy"
-version = "1.13.0"
-description = "Fundamental algorithms for scientific computing in Python"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "scipy-1.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ba419578ab343a4e0a77c0ef82f088238a93eef141b2b8017e46149776dfad4d"},
-    {file = "scipy-1.13.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:22789b56a999265431c417d462e5b7f2b487e831ca7bef5edeb56efe4c93f86e"},
-    {file = "scipy-1.13.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:05f1432ba070e90d42d7fd836462c50bf98bd08bed0aa616c359eed8a04e3922"},
-    {file = "scipy-1.13.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8434f6f3fa49f631fae84afee424e2483289dfc30a47755b4b4e6b07b2633a4"},
-    {file = "scipy-1.13.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:dcbb9ea49b0167de4167c40eeee6e167caeef11effb0670b554d10b1e693a8b9"},
-    {file = "scipy-1.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:1d2f7bb14c178f8b13ebae93f67e42b0a6b0fc50eba1cd8021c9b6e08e8fb1cd"},
-    {file = "scipy-1.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0fbcf8abaf5aa2dc8d6400566c1a727aed338b5fe880cde64907596a89d576fa"},
-    {file = "scipy-1.13.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:5e4a756355522eb60fcd61f8372ac2549073c8788f6114449b37e9e8104f15a5"},
-    {file = "scipy-1.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5acd8e1dbd8dbe38d0004b1497019b2dbbc3d70691e65d69615f8a7292865d7"},
-    {file = "scipy-1.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ff7dad5d24a8045d836671e082a490848e8639cabb3dbdacb29f943a678683d"},
-    {file = "scipy-1.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4dca18c3ffee287ddd3bc8f1dabaf45f5305c5afc9f8ab9cbfab855e70b2df5c"},
-    {file = "scipy-1.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:a2f471de4d01200718b2b8927f7d76b5d9bde18047ea0fa8bd15c5ba3f26a1d6"},
-    {file = "scipy-1.13.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d0de696f589681c2802f9090fff730c218f7c51ff49bf252b6a97ec4a5d19e8b"},
-    {file = "scipy-1.13.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:b2a3ff461ec4756b7e8e42e1c681077349a038f0686132d623fa404c0bee2551"},
-    {file = "scipy-1.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bf9fe63e7a4bf01d3645b13ff2aa6dea023d38993f42aaac81a18b1bda7a82a"},
-    {file = "scipy-1.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e7626dfd91cdea5714f343ce1176b6c4745155d234f1033584154f60ef1ff42"},
-    {file = "scipy-1.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:109d391d720fcebf2fbe008621952b08e52907cf4c8c7efc7376822151820820"},
-    {file = "scipy-1.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8930ae3ea371d6b91c203b1032b9600d69c568e537b7988a3073dfe4d4774f21"},
-    {file = "scipy-1.13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5407708195cb38d70fd2d6bb04b1b9dd5c92297d86e9f9daae1576bd9e06f602"},
-    {file = "scipy-1.13.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:ac38c4c92951ac0f729c4c48c9e13eb3675d9986cc0c83943784d7390d540c78"},
-    {file = "scipy-1.13.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09c74543c4fbeb67af6ce457f6a6a28e5d3739a87f62412e4a16e46f164f0ae5"},
-    {file = "scipy-1.13.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28e286bf9ac422d6beb559bc61312c348ca9b0f0dae0d7c5afde7f722d6ea13d"},
-    {file = "scipy-1.13.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:33fde20efc380bd23a78a4d26d59fc8704e9b5fd9b08841693eb46716ba13d86"},
-    {file = "scipy-1.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:45c08bec71d3546d606989ba6e7daa6f0992918171e2a6f7fbedfa7361c2de1e"},
-    {file = "scipy-1.13.0.tar.gz", hash = "sha256:58569af537ea29d3f78e5abd18398459f195546bb3be23d16677fb26616cc11e"},
-]
-
-[package.dependencies]
-numpy = ">=1.22.4,<2.3"
-
-[package.extras]
-dev = ["cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy", "pycodestyle", "pydevtool", "rich-click", "ruff", "types-psutil", "typing_extensions"]
-doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.12.0)", "jupytext", "matplotlib (>=3.5)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0)", "sphinx-design (>=0.4.0)"]
-test = ["array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
-
-[[package]]
 name = "setuptools"
 version = "69.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1053,4 +1011,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "950789a5aea162b9f3b312c7c75b515f051b574bce7df72e6b7837ba83f3d32b"
+content-hash = "0bccb1113d7bfecec1b0374aee94532d3840aa30a5d5e22c3ebf5383e3eef56f"

--- a/psychrochart/chartdata.py
+++ b/psychrochart/chartdata.py
@@ -18,11 +18,10 @@ from psychrolib import (
     GetVapPresFromHumRatio,
     isIP,
 )
-from scipy.interpolate import interp1d
 
 from psychrochart.models.curves import PsychroCurve, PsychroCurves
 from psychrochart.models.styles import AnnotationStyle, CurveStyle
-from psychrochart.util import solve_curves_with_iteration
+from psychrochart.util import Interp1D, solve_curves_with_iteration
 
 f_vec_hum_ratio_from_vap_press = np.vectorize(GetHumRatioFromVapPres)
 f_vec_moist_air_enthalpy = np.vectorize(GetMoistAirEnthalpy)
@@ -273,12 +272,7 @@ def make_constant_enthalpy_lines(
         )
         / _factor_out_h()
     )
-    t_sat_interpolator = interp1d(
-        h_in_sat,
-        saturation_curve.x_data,
-        fill_value="extrapolate",
-        assume_sorted=True,
-    )
+    t_sat_interpolator = Interp1D(h_in_sat, saturation_curve.x_data)
     h_min = (
         GetMoistAirEnthalpy(
             dbt_min_seen or saturation_curve.x_data[0],
@@ -412,12 +406,7 @@ def make_constant_specific_volume_lines(
     temps_max_constant_v = f_vec_dry_temp_from_spec_vol(
         np.array(v_objective), w_humidity_ratio_min / _factor_out_w(), pressure
     )
-    t_sat_interpolator = interp1d(
-        v_in_sat,
-        saturation_curve.x_data,
-        fill_value="extrapolate",
-        assume_sorted=True,
-    )
+    t_sat_interpolator = Interp1D(v_in_sat, saturation_curve.x_data)
     t_sat_points = solve_curves_with_iteration(
         "CONSTANT VOLUME",
         v_objective,

--- a/psychrochart/process_logic.py
+++ b/psychrochart/process_logic.py
@@ -9,7 +9,6 @@ from psychrolib import (
     SetUnitSystem,
     SI,
 )
-from scipy.interpolate import interp1d
 
 from psychrochart.chartdata import (
     get_rh_max_min_in_limits,
@@ -24,6 +23,7 @@ from psychrochart.chartdata import (
 from psychrochart.chartzones import make_zone_curve
 from psychrochart.models.config import ChartConfig, ChartLimits, DEFAULT_ZONES
 from psychrochart.models.curves import PsychroChartModel
+from psychrochart.util import Interp1D
 
 spec_vol_vec = np.vectorize(psy.GetMoistAirVolume)
 
@@ -53,10 +53,9 @@ def _gen_interior_lines(config: ChartConfig, chart: PsychroChartModel) -> None:
     # check if sat curve cuts x-axis with T > config.dbt_min
     dbt_min_seen: float | None = None
     if chart.saturation.y_data[0] < config.w_min:
-        temp_sat_interpolator = interp1d(
+        temp_sat_interpolator = Interp1D(
             chart.saturation.y_data,
             chart.saturation.x_data,
-            assume_sorted=True,
         )
         dbt_min_seen = temp_sat_interpolator(config.w_min)
 

--- a/psychrochart/util.py
+++ b/psychrochart/util.py
@@ -9,6 +9,30 @@ NUM_ITERS_MAX = 100
 TESTING_MODE = os.getenv("PYTEST_CURRENT_TEST") is not None
 
 
+class Interp1D:
+    """Simple 1D interpolation with extrapolation."""
+
+    def __init__(self, x: Sequence[float], y: Sequence[float]):
+        self.x = np.array(x)
+        self.y = np.array(y)
+
+    def __call__(self, x_new: float) -> float:
+        """Linear interpolation with extrapolation."""
+        # Perform linear interpolation
+        for i in range(len(self.x) - 1):
+            if self.x[i] <= x_new <= self.x[i + 1]:
+                slope = (self.y[i + 1] - self.y[i]) / (
+                    self.x[i + 1] - self.x[i]
+                )
+                return float(self.y[i] + slope * (x_new - self.x[i]))
+
+        # Extrapolation
+        assert x_new < self.x[0] or x_new > self.x[-1]
+        i = 1 if x_new < self.x[0] else -1
+        slope = (self.y[i] - self.y[i - 1]) / (self.x[i] - self.x[i - 1])
+        return float(self.y[i] + slope * (x_new - self.x[i]))
+
+
 def _iter_solver(
     initial_value: np.ndarray,
     objective_value: np.ndarray,

--- a/psychrochart/util.py
+++ b/psychrochart/util.py
@@ -33,6 +33,64 @@ class Interp1D:
         return float(self.y[i] + slope * (x_new - self.x[i]))
 
 
+def orientation(
+    p: tuple[float, float],
+    q: tuple[float, float],
+    r: tuple[float, float],
+) -> int:
+    """
+    Function to find orientation of ordered triplet (p, q, r).
+    Returns:
+    0 : Colinear points
+    1 : Clockwise points
+    2 : Counterclockwise points
+    """
+    val = (q[1] - p[1]) * (r[0] - q[0]) - (q[0] - p[0]) * (r[1] - q[1])
+    if val == 0:  # pragma: no cover
+        return 0  # Colinear
+    elif val > 0:
+        return 1  # Clockwise
+    else:
+        return 2  # Counterclockwise
+
+
+def convex_hull_graham_scan(
+    points: list[tuple[float, float]],
+) -> tuple[list[float], list[float]]:
+    """Function to compute the convex hull of a set of 2-D points."""
+    # If number of points is less than 3, convex hull is not possible
+    numpoints = len(points)
+    assert numpoints >= 3
+
+    # Find the leftmost point
+    leftp = min(points)
+
+    # Sort points based on polar angle with respect to the leftmost point
+    sorted_points = sorted(
+        [p for p in points if p != leftp],
+        key=lambda x: (
+            np.arctan2(x[1] - leftp[1], x[0] - leftp[0]),
+            x[0],
+            x[1],
+        ),
+    )
+
+    # Initialize an empty stack to store points on the convex hull
+    # Start from the leftmost point and proceed to build the convex hull
+    hull = [leftp, sorted_points[0]]
+    for i in range(1, len(sorted_points)):
+        while (
+            len(hull) > 1
+            and orientation(hull[-2], hull[-1], sorted_points[i]) != 2
+        ):
+            hull.pop()
+        hull.append(sorted_points[i])
+
+    hull_x, hull_y = list(zip(*hull))
+    assert len(hull_x) >= 2
+    return list(hull_x), list(hull_y)
+
+
 def _iter_solver(
     initial_value: np.ndarray,
     objective_value: np.ndarray,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ log_date_format = "%Y-%m-%d %H:%M:%S"
 
 [tool.poetry]
 name = "psychrochart"
-version = "0.10.0"
+version = "0.11.0"
 description = "A python 3 library to make psychrometric charts and overlay information on them"
 authors = ["Eugenio Panadero <eugenio.panadero@gmail.com>"]
 packages = [
@@ -92,7 +92,6 @@ include = ["CHANGELOG.md"]
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
 matplotlib = ">=3.7"
-scipy = ">=1.10"
 psychrolib = ">=2.5"
 pydantic = ">=2.3.0"
 python-slugify = ">=8.0.1"

--- a/tests/example-charts/test_ha_addon_psychrochart.svg
+++ b/tests/example-charts/test_ha_addon_psychrochart.svg
@@ -57,18 +57,18 @@ z
 " clip-path="url(#p411d26f6a5)" style="fill: #7f9fff; fill-opacity: 0.5; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #7f9fcc; stroke-width: 2; stroke-linejoin: miter"/>
    </g>
    <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa">
-    <path d="M 642.048 351.244972 
-L 580.608 404.875619 
+    <path d="M 580.608 404.875619 
 L 625.92 445.719156 
 L 675.84 447.746596 
 L 777.216 413.099015 
+L 642.048 351.244972 
 z
 " clip-path="url(#p411d26f6a5)" style="fill: #008000; opacity: 0.3"/>
    </g>
    <g id="convexhull_galeria_sombra_terraza_terraza_sombra">
-    <path d="M 391.68 185.033723 
-L 269.568 363.717527 
+    <path d="M 269.568 363.717527 
 L 298.752 349.164848 
+L 391.68 185.033723 
 z
 " clip-path="url(#p411d26f6a5)" style="fill: #e37207; opacity: 0.2"/>
    </g>
@@ -1038,44 +1038,20 @@ z
      <use xlink:href="#mf0b808afb0" x="298.752" y="349.164848" style="fill: #cc9706; fill-opacity: 0.9; stroke: #cc9706; stroke-opacity: 0.9"/>
     </g>
    </g>
-   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa_s1">
-    <path d="M 642.048 351.244972 
-L 580.608 404.875619 
-" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 2,3.3; stroke-dashoffset: 0; stroke: #006400; stroke-opacity: 0.5; stroke-width: 2"/>
-   </g>
-   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa_s2">
-    <path d="M 642.048 351.244972 
-L 777.216 413.099015 
-" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 2,3.3; stroke-dashoffset: 0; stroke: #006400; stroke-opacity: 0.5; stroke-width: 2"/>
-   </g>
-   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa_s3">
-    <path d="M 625.92 445.719156 
-L 580.608 404.875619 
-" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 2,3.3; stroke-dashoffset: 0; stroke: #006400; stroke-opacity: 0.5; stroke-width: 2"/>
-   </g>
-   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa_s4">
-    <path d="M 675.84 447.746596 
-L 777.216 413.099015 
-" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 2,3.3; stroke-dashoffset: 0; stroke: #006400; stroke-opacity: 0.5; stroke-width: 2"/>
-   </g>
-   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa_s5">
-    <path d="M 675.84 447.746596 
+   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa_edge">
+    <path d="M 580.608 404.875619 
 L 625.92 445.719156 
+L 675.84 447.746596 
+L 777.216 413.099015 
+L 642.048 351.244972 
+L 580.608 404.875619 
 " clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 2,3.3; stroke-dashoffset: 0; stroke: #006400; stroke-opacity: 0.5; stroke-width: 2"/>
    </g>
-   <g id="convexhull_galeria_sombra_terraza_terraza_sombra_s1">
-    <path d="M 391.68 185.033723 
-L 269.568 363.717527 
-" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #e37207; stroke-opacity: 0.5"/>
-   </g>
-   <g id="convexhull_galeria_sombra_terraza_terraza_sombra_s2">
-    <path d="M 298.752 349.164848 
-L 269.568 363.717527 
-" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #e37207; stroke-opacity: 0.5"/>
-   </g>
-   <g id="convexhull_galeria_sombra_terraza_terraza_sombra_s3">
-    <path d="M 298.752 349.164848 
+   <g id="convexhull_galeria_sombra_terraza_terraza_sombra_edge">
+    <path d="M 269.568 363.717527 
+L 298.752 349.164848 
 L 391.68 185.033723 
+L 269.568 363.717527 
 " clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #e37207; stroke-opacity: 0.5"/>
    </g>
    <g id="chart_y_axis_right_line">

--- a/tests/example-charts/test_ha_addon_psychrochart.svg
+++ b/tests/example-charts/test_ha_addon_psychrochart.svg
@@ -1,0 +1,2630 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1152pt" height="648pt" viewBox="0 0 1152 648" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_psychrochart">
+  <g id="chart_axes">
+   <g id="chart_background">
+    <path d="M 0 648 
+L 1152 648 
+L 1152 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="zone_dbt_rh_summer">
+    <path d="M 844.8 290.586445 
+L 883.2 269.323948 
+L 921.6 247.471255 
+L 960 225.013793 
+L 998.4 201.936657 
+L 998.4 397.198221 
+L 960 414.34434 
+L 921.6 431.034738 
+L 883.2 447.280116 
+L 844.8 463.09095 
+z
+" clip-path="url(#p411d26f6a5)" style="fill: #ffbf00; fill-opacity: 0.5; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #ffbf00; stroke-opacity: 0.8; stroke-width: 2; stroke-linejoin: miter"/>
+   </g>
+   <g id="zone_dbt_rh_winter">
+    <path d="M 691.2 471.591305 
+L 729.6 455.803731 
+L 768 439.575081 
+L 806.4 422.894533 
+L 844.8 405.751029 
+L 844.8 520.270196 
+L 806.4 533.909402 
+L 768 547.182506 
+L 729.6 560.098129 
+L 691.2 572.66471 
+z
+" clip-path="url(#p411d26f6a5)" style="fill: #7f9fff; fill-opacity: 0.5; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #7f9fcc; stroke-width: 2; stroke-linejoin: miter"/>
+   </g>
+   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa">
+    <path d="M 642.048 351.244972 
+L 580.608 404.875619 
+L 625.92 445.719156 
+L 675.84 447.746596 
+L 777.216 413.099015 
+z
+" clip-path="url(#p411d26f6a5)" style="fill: #008000; opacity: 0.3"/>
+   </g>
+   <g id="convexhull_galeria_sombra_terraza_terraza_sombra">
+    <path d="M 391.68 185.033723 
+L 269.568 363.717527 
+L 298.752 349.164848 
+z
+" clip-path="url(#p411d26f6a5)" style="fill: #e37207; opacity: 0.2"/>
+   </g>
+   <g id="chart_x_axis">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m1cceb5811c" d="M 0 0 
+L 0 -3.5 
+" style="stroke: #da251d; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m1cceb5811c" x="384" y="648" style="fill: #da251d; stroke: #da251d; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 17 -->
+      <g style="fill: #da251d" transform="translate(377.6375 635.598438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m1cceb5811c" x="768" y="648" style="fill: #da251d; stroke: #da251d; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 22 -->
+      <g style="fill: #da251d" transform="translate(761.6375 635.598438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="chart_y_axis">
+    <g id="ytick_1">
+     <g id="line2d_3">
+      <defs>
+       <path id="me33c01d06b" d="M 0 0 
+L -3.5 0 
+" style="stroke: #002060; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#me33c01d06b" x="1152" y="583.2" style="fill: #002060; stroke: #002060; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 6 -->
+      <g style="fill: #002060" transform="translate(1132 586.999219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#me33c01d06b" x="1152" y="518.4" style="fill: #002060; stroke: #002060; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 7 -->
+      <g style="fill: #002060" transform="translate(1132 522.199219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-37"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#me33c01d06b" x="1152" y="453.6" style="fill: #002060; stroke: #002060; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 8 -->
+      <g style="fill: #002060" transform="translate(1132 457.399219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#me33c01d06b" x="1152" y="388.8" style="fill: #002060; stroke: #002060; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 9 -->
+      <g style="fill: #002060" transform="translate(1132 392.599219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-39"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#me33c01d06b" x="1152" y="324" style="fill: #002060; stroke: #002060; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 10 -->
+      <g style="fill: #002060" transform="translate(1132 327.799219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#me33c01d06b" x="1152" y="259.2" style="fill: #002060; stroke: #002060; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 11 -->
+      <g style="fill: #002060" transform="translate(1132 262.999219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#me33c01d06b" x="1152" y="194.4" style="fill: #002060; stroke: #002060; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 12 -->
+      <g style="fill: #002060" transform="translate(1132 198.199219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#me33c01d06b" x="1152" y="129.6" style="fill: #002060; stroke: #002060; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 13 -->
+      <g style="fill: #002060" transform="translate(1132 133.399219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#me33c01d06b" x="1152" y="64.8" style="fill: #002060; stroke: #002060; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 14 -->
+      <g style="fill: #002060" transform="translate(1132 68.599219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="constant_dry_temp_data_12">
+    <path d="M -0 648 
+L -0 406.825592 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #da251d; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_dry_temp_data_17">
+    <path d="M 384 648 
+L 384 186.900769 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #da251d; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_dry_temp_data_22">
+    <path d="M 768 648 
+L 768 -1 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #da251d; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_5_5">
+    <path d="M -1 615.6 
+L 1152 615.6 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_6">
+    <path d="M -1 583.2 
+L 1152 583.2 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_6_5">
+    <path d="M -1 550.8 
+L 1152 550.8 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_7">
+    <path d="M -1 518.4 
+L 1152 518.4 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_7_5">
+    <path d="M -1 486 
+L 1152 486 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_8">
+    <path d="M -1 453.6 
+L 1152 453.6 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_8_5">
+    <path d="M -1 421.2 
+L 1152 421.2 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_9">
+    <path d="M 36.118254 388.8 
+L 1152 388.8 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_9_5">
+    <path d="M 98.595915 356.4 
+L 1152 356.4 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_10">
+    <path d="M 158.193566 324 
+L 1152 324 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_10_5">
+    <path d="M 215.177215 291.6 
+L 1152 291.6 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_11">
+    <path d="M 269.776972 259.2 
+L 1152 259.2 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_11_5">
+    <path d="M 322.193285 226.8 
+L 1152 226.8 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_12">
+    <path d="M 372.601871 194.4 
+L 1152 194.4 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_12_5">
+    <path d="M 421.157656 162 
+L 1152 162 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_13">
+    <path d="M 467.997959 129.6 
+L 1152 129.6 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_13_5">
+    <path d="M 513.245088 97.2 
+L 1152 97.2 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_14">
+    <path d="M 557.008465 64.8 
+L 1152 64.8 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_14_5">
+    <path d="M 599.386396 32.4 
+L 1152 32.4 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_humidity_data_15">
+    <path d="M 640.467538 0 
+L 1152 0 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 0.75,1.2375; stroke-dashoffset: 0; stroke: #002060; stroke-opacity: 0.7; stroke-width: 0.75"/>
+   </g>
+   <g id="constant_h_data_25">
+    <path d="M -1 639.63801 
+L 23.555127 648 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_h_data_30">
+    <path d="M -1 510.989719 
+L 401.768463 648 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_h_data_35">
+    <path d="M 28.076836 392.857202 
+L 779.981798 648 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_h_data_40">
+    <path d="M 174.715327 314.751499 
+L 1153 646.239648 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_h_data_45">
+    <path d="M 311.594573 233.456008 
+L 1153 518.23361 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_h_data_50">
+    <path d="M 439.545487 149.416987 
+L 1153 390.568103 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_h_data_55">
+    <path d="M 559.625825 62.828448 
+L 1153 263.165293 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_h_data_60">
+    <path d="M 746.728482 -1 
+L 1153 136.019942 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_h_data_65">
+    <path d="M 1123.058803 -1 
+L 1153 9.088156 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_h_data_70">
+    <path clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_h_data_75">
+    <path clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_h_data_80">
+    <path clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #400080; stroke-opacity: 0.7; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="constant_v_data_0_82">
+    <path d="M 34.653857 389.540734 
+L 174.212307 648 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #008056; stroke-opacity: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="constant_v_data_0_83">
+    <path d="M 240.904168 276.501793 
+L 443.404165 648 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #008056; stroke-opacity: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="constant_v_data_0_84">
+    <path d="M 438.709421 149.992908 
+L 712.596022 648 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #008056; stroke-opacity: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="constant_v_data_0_85">
+    <path d="M 627.941489 9.98418 
+L 981.787879 648 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #008056; stroke-opacity: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="constant_v_data_0_86">
+    <path d="M 888.204274 -1 
+L 1153 472.715683 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #008056; stroke-opacity: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="constant_v_data_0_87">
+    <path clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #008056; stroke-opacity: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="constant_v_data_0_88">
+    <path clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #008056; stroke-opacity: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="constant_rh_data_40">
+    <path d="M 431.793442 649 
+L 460.8 641.185353 
+L 499.2 630.545344 
+L 537.6 619.603374 
+L 576 608.352005 
+L 614.4 596.783639 
+L 652.8 584.890516 
+L 691.2 572.66471 
+L 729.6 560.098129 
+L 768 547.182506 
+L 806.4 533.909402 
+L 844.8 520.270196 
+L 883.2 506.256086 
+L 921.6 491.858082 
+L 960 477.067007 
+L 998.4 461.873486 
+L 1036.8 446.267948 
+L 1075.2 430.240619 
+L 1113.6 413.781518 
+L 1152 396.880453 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 12.8,3.2,2,3.2; stroke-dashoffset: 0; stroke: #007fff; stroke-opacity: 0.7; stroke-width: 2"/>
+   </g>
+   <g id="constant_rh_data_50">
+    <path d="M 163.85878 649 
+L 192 641.212194 
+L 230.4 630.273441 
+L 268.8 619.014785 
+L 307.2 607.428079 
+L 345.6 595.504992 
+L 384 583.237011 
+L 422.4 570.615434 
+L 460.8 557.631366 
+L 499.2 544.275718 
+L 537.6 530.539197 
+L 576 516.412307 
+L 614.4 501.885344 
+L 652.8 486.948389 
+L 691.2 471.591305 
+L 729.6 455.803731 
+L 768 439.575081 
+L 806.4 422.894533 
+L 844.8 405.751029 
+L 883.2 388.133267 
+L 921.6 370.029696 
+L 960 351.428512 
+L 998.4 332.317649 
+L 1036.8 312.684776 
+L 1075.2 292.51729 
+L 1113.6 271.802309 
+L 1152 250.526667 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 12.8,3.2,2,3.2; stroke-dashoffset: 0; stroke: #007fff; stroke-opacity: 0.7; stroke-width: 2"/>
+   </g>
+   <g id="constant_rh_data_60">
+    <path d="M -0 634.786915 
+L 38.4 623.408237 
+L 76.8 611.689389 
+L 115.2 599.621485 
+L 153.6 587.195439 
+L 192 574.401959 
+L 230.4 561.231537 
+L 268.8 547.674452 
+L 307.2 533.72076 
+L 345.6 519.360293 
+L 384 504.582649 
+L 422.4 489.377193 
+L 460.8 473.733045 
+L 499.2 457.639082 
+L 537.6 441.083925 
+L 576 424.05594 
+L 614.4 406.543226 
+L 652.8 388.533615 
+L 691.2 370.01466 
+L 729.6 350.973632 
+L 768 331.397514 
+L 806.4 311.272991 
+L 844.8 290.586445 
+L 883.2 269.323948 
+L 921.6 247.471255 
+L 960 225.013793 
+L 998.4 201.936657 
+L 1036.8 178.224601 
+L 1075.2 153.862026 
+L 1113.6 128.832976 
+L 1152 103.121126 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 12.8,3.2,2,3.2; stroke-dashoffset: 0; stroke: #007fff; stroke-opacity: 0.7; stroke-width: 2"/>
+   </g>
+   <g id="constant_rh_data_80">
+    <path d="M -0 521.12504 
+L 38.4 505.867047 
+L 76.8 490.149897 
+L 115.2 473.961405 
+L 153.6 457.289096 
+L 192 440.120199 
+L 230.4 422.441637 
+L 268.8 404.240023 
+L 307.2 385.50165 
+L 345.6 366.212486 
+L 384 346.358164 
+L 422.4 325.923972 
+L 460.8 304.894849 
+L 499.2 283.255373 
+L 537.6 260.989752 
+L 576 238.081817 
+L 614.4 214.51501 
+L 652.8 190.272374 
+L 691.2 165.336544 
+L 729.6 139.689735 
+L 768 113.313734 
+L 806.4 86.189884 
+L 844.8 58.299075 
+L 883.2 29.621731 
+L 921.6 0.137797 
+L 923.041435 -1 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 12.8,3.2,2,3.2; stroke-dashoffset: 0; stroke: #007fff; stroke-opacity: 0.7; stroke-width: 2"/>
+   </g>
+   <g id="constant_wbt_data_15">
+    <path d="M 230.4 282.702231 
+L 1152 603.245998 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #7fdfff; stroke-opacity: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="constant_wbt_data_20">
+    <path d="M 614.4 20.673669 
+L 1152 210.6262 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #7fdfff; stroke-opacity: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="saturation_100">
+    <path d="M -0 406.825592 
+L 38.4 387.644145 
+L 76.8 367.881665 
+L 115.2 347.522487 
+L 153.6 326.550557 
+L 192 304.949425 
+L 230.4 282.702231 
+L 268.8 259.791697 
+L 307.2 236.200117 
+L 345.6 211.909341 
+L 384 186.900769 
+L 422.4 161.155332 
+L 460.8 134.653487 
+L 499.2 107.375199 
+L 537.6 79.299927 
+L 576 50.406614 
+L 614.4 20.673669 
+L 641.603028 -1 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke: #da251d; stroke-width: 5; stroke-linecap: square"/>
+   </g>
+   <g id="point_aseo">
+    <path d="M 662.784 424.907164 
+" clip-path="url(#p411d26f6a5)" style="fill: none"/>
+    <defs>
+     <path id="m3d1f41463b" d="M 0 4 
+C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
+C 3.578535 2.078319 4 1.060812 4 0 
+C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
+C 2.078319 -3.578535 1.060812 -4 0 -4 
+C -1.060812 -4 -2.078319 -3.578535 -2.828427 -2.828427 
+C -3.578535 -2.078319 -4 -1.060812 -4 0 
+C -4 1.060812 -3.578535 2.078319 -2.828427 2.828427 
+C -2.078319 3.578535 -1.060812 4 0 4 
+z
+" style="stroke: #007bff; stroke-opacity: 0.9"/>
+    </defs>
+    <g clip-path="url(#p411d26f6a5)">
+     <use xlink:href="#m3d1f41463b" x="662.784" y="424.907164" style="fill: #007bff; fill-opacity: 0.9; stroke: #007bff; stroke-opacity: 0.9"/>
+    </g>
+   </g>
+   <g id="point_cocina">
+    <path d="M 625.92 445.719156 
+" clip-path="url(#p411d26f6a5)" style="fill: none"/>
+    <defs>
+     <path id="mc1d245121d" d="M 0 4.5 
+C 1.193414 4.5 2.338109 4.025852 3.181981 3.181981 
+C 4.025852 2.338109 4.5 1.193414 4.5 0 
+C 4.5 -1.193414 4.025852 -2.338109 3.181981 -3.181981 
+C 2.338109 -4.025852 1.193414 -4.5 0 -4.5 
+C -1.193414 -4.5 -2.338109 -4.025852 -3.181981 -3.181981 
+C -4.025852 -2.338109 -4.5 -1.193414 -4.5 0 
+C -4.5 1.193414 -4.025852 2.338109 -3.181981 3.181981 
+C -2.338109 4.025852 -1.193414 4.5 0 4.5 
+z
+" style="stroke: #f15346; stroke-opacity: 0.9"/>
+    </defs>
+    <g clip-path="url(#p411d26f6a5)">
+     <use xlink:href="#mc1d245121d" x="625.92" y="445.719156" style="fill: #f15346; fill-opacity: 0.9; stroke: #f15346; stroke-opacity: 0.9"/>
+    </g>
+   </g>
+   <g id="point_dormitorio_esp">
+    <path d="M 614.4 415.142273 
+" clip-path="url(#p411d26f6a5)" style="fill: none"/>
+    <defs>
+     <path id="m6f960fba47" d="M 0 5 
+C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
+C 4.473168 2.597899 5 1.326016 5 0 
+C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
+C 2.597899 -4.473168 1.326016 -5 0 -5 
+C -1.326016 -5 -2.597899 -4.473168 -3.535534 -3.535534 
+C -4.473168 -2.597899 -5 -1.326016 -5 0 
+C -5 1.326016 -4.473168 2.597899 -3.535534 3.535534 
+C -2.597899 4.473168 -1.326016 5 0 5 
+z
+" style="stroke: #006400; stroke-opacity: 0.9"/>
+    </defs>
+    <g clip-path="url(#p411d26f6a5)">
+     <use xlink:href="#m6f960fba47" x="614.4" y="415.142273" style="fill: #006400; fill-opacity: 0.9; stroke: #006400; stroke-opacity: 0.9"/>
+    </g>
+   </g>
+   <g id="point_dormitorio">
+    <path d="M 580.608 404.875619 
+" clip-path="url(#p411d26f6a5)" style="fill: none"/>
+    <defs>
+     <path id="m5940930abb" d="M 0 5 
+C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
+C 4.473168 2.597899 5 1.326016 5 0 
+C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
+C 2.597899 -4.473168 1.326016 -5 0 -5 
+C -1.326016 -5 -2.597899 -4.473168 -3.535534 -3.535534 
+C -4.473168 -2.597899 -5 -1.326016 -5 0 
+C -5 1.326016 -4.473168 2.597899 -3.535534 3.535534 
+C -2.597899 4.473168 -1.326016 5 0 5 
+z
+" style="stroke: #51e81f; stroke-opacity: 0.9"/>
+    </defs>
+    <g clip-path="url(#p411d26f6a5)">
+     <use xlink:href="#m5940930abb" x="580.608" y="404.875619" style="fill: #51e81f; fill-opacity: 0.9; stroke: #51e81f; stroke-opacity: 0.9"/>
+    </g>
+   </g>
+   <g id="point_estudio">
+    <path d="M 668.16 427.095878 
+" clip-path="url(#p411d26f6a5)" style="fill: none"/>
+    <defs>
+     <path id="md4aa962cdf" d="M 0 4.5 
+C 1.193414 4.5 2.338109 4.025852 3.181981 3.181981 
+C 4.025852 2.338109 4.5 1.193414 4.5 0 
+C 4.5 -1.193414 4.025852 -2.338109 3.181981 -3.181981 
+C 2.338109 -4.025852 1.193414 -4.5 0 -4.5 
+C -1.193414 -4.5 -2.338109 -4.025852 -3.181981 -3.181981 
+C -4.025852 -2.338109 -4.5 -1.193414 -4.5 0 
+C -4.5 1.193414 -4.025852 2.338109 -3.181981 3.181981 
+C -2.338109 4.025852 -1.193414 4.5 0 4.5 
+z
+" style="stroke: #ffa067; stroke-opacity: 0.9"/>
+    </defs>
+    <g clip-path="url(#p411d26f6a5)">
+     <use xlink:href="#md4aa962cdf" x="668.16" y="427.095878" style="fill: #ffa067; fill-opacity: 0.9; stroke: #ffa067; stroke-opacity: 0.9"/>
+    </g>
+   </g>
+   <g id="point_office">
+    <path d="M 675.84 447.746596 
+" clip-path="url(#p411d26f6a5)" style="fill: none"/>
+    <defs>
+     <path id="m133bfd70b6" d="M 0 6 
+C 1.591219 6 3.117479 5.367802 4.242641 4.242641 
+C 5.367802 3.117479 6 1.591219 6 0 
+C 6 -1.591219 5.367802 -3.117479 4.242641 -4.242641 
+C 3.117479 -5.367802 1.591219 -6 0 -6 
+C -1.591219 -6 -3.117479 -5.367802 -4.242641 -4.242641 
+C -5.367802 -3.117479 -6 -1.591219 -6 0 
+C -6 1.591219 -5.367802 3.117479 -4.242641 4.242641 
+C -3.117479 5.367802 -1.591219 6 0 6 
+z
+" style="stroke: #bb1247; stroke-opacity: 0.9"/>
+    </defs>
+    <g clip-path="url(#p411d26f6a5)">
+     <use xlink:href="#m133bfd70b6" x="675.84" y="447.746596" style="fill: #bb1247; fill-opacity: 0.9; stroke: #bb1247; stroke-opacity: 0.9"/>
+    </g>
+   </g>
+   <g id="point_office_window">
+    <path d="M 642.048 351.244972 
+" clip-path="url(#p411d26f6a5)" style="fill: none"/>
+    <defs>
+     <path id="m994465bce8" d="M 0 6 
+C 1.591219 6 3.117479 5.367802 4.242641 4.242641 
+C 5.367802 3.117479 6 1.591219 6 0 
+C 6 -1.591219 5.367802 -3.117479 4.242641 -4.242641 
+C 3.117479 -5.367802 1.591219 -6 0 -6 
+C -1.591219 -6 -3.117479 -5.367802 -4.242641 -4.242641 
+C -5.367802 -3.117479 -6 -1.591219 -6 0 
+C -6 1.591219 -5.367802 3.117479 -4.242641 4.242641 
+C -3.117479 5.367802 -1.591219 6 0 6 
+z
+" style="stroke: #bb2b1e; stroke-opacity: 0.9"/>
+    </defs>
+    <g clip-path="url(#p411d26f6a5)">
+     <use xlink:href="#m994465bce8" x="642.048" y="351.244972" style="fill: #bb2b1e; fill-opacity: 0.9; stroke: #bb2b1e; stroke-opacity: 0.9"/>
+    </g>
+   </g>
+   <g id="point_sofa">
+    <path d="M 777.216 413.099015 
+" clip-path="url(#p411d26f6a5)" style="fill: none"/>
+    <defs>
+     <path id="mb616c96a6a" d="M 0 5 
+C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
+C 4.473168 2.597899 5 1.326016 5 0 
+C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
+C 2.597899 -4.473168 1.326016 -5 0 -5 
+C -1.326016 -5 -2.597899 -4.473168 -3.535534 -3.535534 
+C -4.473168 -2.597899 -5 -1.326016 -5 0 
+C -5 1.326016 -4.473168 2.597899 -3.535534 3.535534 
+C -2.597899 4.473168 -1.326016 5 0 5 
+z
+" style="stroke: #e3db55; stroke-opacity: 0.8"/>
+    </defs>
+    <g clip-path="url(#p411d26f6a5)">
+     <use xlink:href="#mb616c96a6a" x="777.216" y="413.099015" style="fill: #e3db55; fill-opacity: 0.8; stroke: #e3db55; stroke-opacity: 0.8"/>
+    </g>
+   </g>
+   <g id="point_galeria_sombra">
+    <path d="M 269.568 363.717527 
+" clip-path="url(#p411d26f6a5)" style="fill: none"/>
+    <defs>
+     <path id="ma5aaff8181" d="M 0 5.5 
+C 1.458617 5.5 2.857689 4.920485 3.889087 3.889087 
+C 4.920485 2.857689 5.5 1.458617 5.5 0 
+C 5.5 -1.458617 4.920485 -2.857689 3.889087 -3.889087 
+C 2.857689 -4.920485 1.458617 -5.5 0 -5.5 
+C -1.458617 -5.5 -2.857689 -4.920485 -3.889087 -3.889087 
+C -4.920485 -2.857689 -5.5 -1.458617 -5.5 0 
+C -5.5 1.458617 -4.920485 2.857689 -3.889087 3.889087 
+C -2.857689 4.920485 -1.458617 5.5 0 5.5 
+z
+" style="stroke: #fb6150; stroke-opacity: 0.9"/>
+    </defs>
+    <g clip-path="url(#p411d26f6a5)">
+     <use xlink:href="#ma5aaff8181" x="269.568" y="363.717527" style="fill: #fb6150; fill-opacity: 0.9; stroke: #fb6150; stroke-opacity: 0.9"/>
+    </g>
+   </g>
+   <g id="point_terraza">
+    <path d="M 391.68 185.033723 
+" clip-path="url(#p411d26f6a5)" style="fill: none"/>
+    <defs>
+     <path id="m5beda3621f" d="M 0 6 
+C 1.591219 6 3.117479 5.367802 4.242641 4.242641 
+C 5.367802 3.117479 6 1.591219 6 0 
+C 6 -1.591219 5.367802 -3.117479 4.242641 -4.242641 
+C 3.117479 -5.367802 1.591219 -6 0 -6 
+C -1.591219 -6 -3.117479 -5.367802 -4.242641 -4.242641 
+C -5.367802 -3.117479 -6 -1.591219 -6 0 
+C -6 1.591219 -5.367802 3.117479 -4.242641 4.242641 
+C -3.117479 5.367802 -1.591219 6 0 6 
+z
+" style="stroke: #e37207; stroke-opacity: 0.7"/>
+    </defs>
+    <g clip-path="url(#p411d26f6a5)">
+     <use xlink:href="#m5beda3621f" x="391.68" y="185.033723" style="fill: #e37207; fill-opacity: 0.7; stroke: #e37207; stroke-opacity: 0.7"/>
+    </g>
+   </g>
+   <g id="point_terraza_sombra">
+    <path d="M 298.752 349.164848 
+" clip-path="url(#p411d26f6a5)" style="fill: none"/>
+    <defs>
+     <path id="mf0b808afb0" d="M 0 5.5 
+C 1.458617 5.5 2.857689 4.920485 3.889087 3.889087 
+C 4.920485 2.857689 5.5 1.458617 5.5 0 
+C 5.5 -1.458617 4.920485 -2.857689 3.889087 -3.889087 
+C 2.857689 -4.920485 1.458617 -5.5 0 -5.5 
+C -1.458617 -5.5 -2.857689 -4.920485 -3.889087 -3.889087 
+C -4.920485 -2.857689 -5.5 -1.458617 -5.5 0 
+C -5.5 1.458617 -4.920485 2.857689 -3.889087 3.889087 
+C -2.857689 4.920485 -1.458617 5.5 0 5.5 
+z
+" style="stroke: #cc9706; stroke-opacity: 0.9"/>
+    </defs>
+    <g clip-path="url(#p411d26f6a5)">
+     <use xlink:href="#mf0b808afb0" x="298.752" y="349.164848" style="fill: #cc9706; fill-opacity: 0.9; stroke: #cc9706; stroke-opacity: 0.9"/>
+    </g>
+   </g>
+   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa_s1">
+    <path d="M 642.048 351.244972 
+L 580.608 404.875619 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 2,3.3; stroke-dashoffset: 0; stroke: #006400; stroke-opacity: 0.5; stroke-width: 2"/>
+   </g>
+   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa_s2">
+    <path d="M 642.048 351.244972 
+L 777.216 413.099015 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 2,3.3; stroke-dashoffset: 0; stroke: #006400; stroke-opacity: 0.5; stroke-width: 2"/>
+   </g>
+   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa_s3">
+    <path d="M 625.92 445.719156 
+L 580.608 404.875619 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 2,3.3; stroke-dashoffset: 0; stroke: #006400; stroke-opacity: 0.5; stroke-width: 2"/>
+   </g>
+   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa_s4">
+    <path d="M 675.84 447.746596 
+L 777.216 413.099015 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 2,3.3; stroke-dashoffset: 0; stroke: #006400; stroke-opacity: 0.5; stroke-width: 2"/>
+   </g>
+   <g id="convexhull_aseo_cocina_dormitorio_esp_dormitorio_estudio_office_office_window_sofa_s5">
+    <path d="M 675.84 447.746596 
+L 625.92 445.719156 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 2,3.3; stroke-dashoffset: 0; stroke: #006400; stroke-opacity: 0.5; stroke-width: 2"/>
+   </g>
+   <g id="convexhull_galeria_sombra_terraza_terraza_sombra_s1">
+    <path d="M 391.68 185.033723 
+L 269.568 363.717527 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #e37207; stroke-opacity: 0.5"/>
+   </g>
+   <g id="convexhull_galeria_sombra_terraza_terraza_sombra_s2">
+    <path d="M 298.752 349.164848 
+L 269.568 363.717527 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #e37207; stroke-opacity: 0.5"/>
+   </g>
+   <g id="convexhull_galeria_sombra_terraza_terraza_sombra_s3">
+    <path d="M 298.752 349.164848 
+L 391.68 185.033723 
+" clip-path="url(#p411d26f6a5)" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #e37207; stroke-opacity: 0.5"/>
+   </g>
+   <g id="chart_y_axis_right_line">
+    <path d="M 1152 648 
+L 1152 0 
+" style="fill: none; stroke: #002060; stroke-width: 2; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="chart_x_axis_bottom_line">
+    <path d="M -0 648 
+L 1152 648 
+" style="fill: none; stroke: #da251d; stroke-width: 2; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="label_constant_h_data_25">
+    <!-- 25 $kJ/kg_{da}$     -->
+    <g style="fill: #300060; opacity: 0.525" transform="translate(-34.363508 626.057991) rotate(-341.194263) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6b" d="M 1172 4863 
+L 1747 4863 
+L 1197 2028 
+L 3169 3500 
+L 3916 3500 
+L 1716 1825 
+L 3322 0 
+L 2625 0 
+L 1131 1709 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-4a" d="M 1069 4666 
+L 1703 4666 
+L 856 325 
+Q 691 -522 298 -901 
+Q -94 -1281 -800 -1281 
+L -1050 -1281 
+L -947 -750 
+L -750 -750 
+Q -328 -750 -109 -509 
+Q 109 -269 225 325 
+L 1069 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-67" d="M 3816 3500 
+L 3219 434 
+Q 3047 -456 2561 -893 
+Q 2075 -1331 1253 -1331 
+Q 950 -1331 690 -1286 
+Q 431 -1241 206 -1147 
+L 313 -588 
+Q 525 -725 762 -790 
+Q 1000 -856 1269 -856 
+Q 1816 -856 2167 -557 
+Q 2519 -259 2631 300 
+L 2681 563 
+Q 2441 288 2122 144 
+Q 1803 0 1434 0 
+Q 903 0 598 351 
+Q 294 703 294 1319 
+Q 294 1803 478 2267 
+Q 663 2731 997 3091 
+Q 1219 3328 1514 3456 
+Q 1809 3584 2131 3584 
+Q 2484 3584 2746 3420 
+Q 3009 3256 3138 2956 
+L 3238 3500 
+L 3816 3500 
+z
+M 2950 2216 
+Q 2950 2641 2750 2872 
+Q 2550 3103 2181 3103 
+Q 1953 3103 1747 3012 
+Q 1541 2922 1394 2759 
+Q 1156 2491 1023 2127 
+Q 891 1763 891 1375 
+Q 891 944 1092 712 
+Q 1294 481 1672 481 
+Q 2219 481 2584 976 
+Q 2950 1472 2950 2216 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-64" d="M 2675 525 
+Q 2444 222 2128 65 
+Q 1813 -91 1428 -91 
+Q 903 -91 598 267 
+Q 294 625 294 1247 
+Q 294 1766 478 2236 
+Q 663 2706 1013 3078 
+Q 1244 3325 1534 3454 
+Q 1825 3584 2144 3584 
+Q 2481 3584 2739 3421 
+Q 2997 3259 3138 2956 
+L 3513 4863 
+L 4091 4863 
+L 3144 0 
+L 2566 0 
+L 2675 525 
+z
+M 891 1350 
+Q 891 897 1095 644 
+Q 1300 391 1663 391 
+Q 1931 391 2161 520 
+Q 2391 650 2566 903 
+Q 2750 1166 2856 1509 
+Q 2963 1853 2963 2188 
+Q 2963 2622 2758 2865 
+Q 2553 3109 2194 3109 
+Q 1922 3109 1687 2981 
+Q 1453 2853 1288 2613 
+Q 1106 2353 998 2009 
+Q 891 1666 891 1350 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-61" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(159.033203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(216.943359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(246.435547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(280.126953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(338.037109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(401.513672 -16.390625) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(445.947266 -16.390625) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(491.577148 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(523.364258 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(555.151367 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(586.938477 0.015625)"/>
+    </g>
+   </g>
+   <g id="label_constant_h_data_50">
+    <!-- 50 $kJ/kg_{da}$     -->
+    <g style="fill: #300060; opacity: 0.525" transform="translate(1094.031641 368.419793) rotate(-341.324495) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(159.033203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(216.943359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(246.435547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(280.126953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(338.037109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(401.513672 -16.390625) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(445.947266 -16.390625) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(491.577148 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(523.364258 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(555.151367 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(586.938477 0.015625)"/>
+    </g>
+   </g>
+   <g id="label_constant_v_data_0_82">
+    <!-- 0.82 $m³/kg_{da}$ -->
+    <g style="fill: #006040; opacity: 0.525" transform="translate(48.021687 409.877768) rotate(-298.367407) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-6d" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-b3" d="M 1638 3500 
+Q 1925 3444 2083 3273 
+Q 2241 3103 2241 2847 
+Q 2241 2459 1944 2250 
+Q 1647 2041 1094 2041 
+Q 916 2041 720 2073 
+Q 525 2106 306 2169 
+L 306 2547 
+Q 469 2463 655 2422 
+Q 841 2381 1050 2381 
+Q 1391 2381 1578 2504 
+Q 1766 2628 1766 2847 
+Q 1766 3078 1592 3197 
+Q 1419 3316 1081 3316 
+L 813 3316 
+L 813 3653 
+L 1106 3653 
+Q 1400 3653 1551 3751 
+Q 1703 3850 1703 4038 
+Q 1703 4219 1547 4314 
+Q 1391 4409 1094 4409 
+Q 969 4409 809 4381 
+Q 650 4353 397 4281 
+L 397 4641 
+Q 625 4694 825 4722 
+Q 1025 4750 1197 4750 
+Q 1647 4750 1911 4565 
+Q 2175 4381 2175 4072 
+Q 2175 3856 2034 3706 
+Q 1894 3556 1638 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-30" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0.015625)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(92.785156 0.015625)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(156.408203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(220.03125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(251.818359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-b3" transform="translate(349.230469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(389.318359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(423.009766 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(480.919922 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(544.396484 -16.390625) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(588.830078 -16.390625) scale(0.7)"/>
+    </g>
+   </g>
+   <g id="label_constant_v_data_0_84">
+    <!-- 0.84 $m³/kg_{da}$ -->
+    <g style="fill: #006040; opacity: 0.525" transform="translate(452.069501 169.927705) rotate(-298.809266) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-30" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0.015625)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(92.785156 0.015625)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(156.408203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(220.03125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(251.818359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-b3" transform="translate(349.230469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(389.318359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(423.009766 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(480.919922 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(544.396484 -16.390625) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(588.830078 -16.390625) scale(0.7)"/>
+    </g>
+   </g>
+   <g id="label_constant_rh_data_40">
+    <!-- RH 40 % -->
+    <g style="fill: #005fbf; opacity: 0.525" transform="translate(900.765312 497.654644) rotate(-21.065899) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-48" d="M 628 4666 
+L 1259 4666 
+L 1259 2753 
+L 3553 2753 
+L 3553 4666 
+L 4184 4666 
+L 4184 0 
+L 3553 0 
+L 3553 2222 
+L 1259 2222 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-25" d="M 4653 2053 
+Q 4381 2053 4226 1822 
+Q 4072 1591 4072 1178 
+Q 4072 772 4226 539 
+Q 4381 306 4653 306 
+Q 4919 306 5073 539 
+Q 5228 772 5228 1178 
+Q 5228 1588 5073 1820 
+Q 4919 2053 4653 2053 
+z
+M 4653 2450 
+Q 5147 2450 5437 2106 
+Q 5728 1763 5728 1178 
+Q 5728 594 5436 251 
+Q 5144 -91 4653 -91 
+Q 4153 -91 3862 251 
+Q 3572 594 3572 1178 
+Q 3572 1766 3864 2108 
+Q 4156 2450 4653 2450 
+z
+M 1428 4353 
+Q 1159 4353 1004 4120 
+Q 850 3888 850 3481 
+Q 850 3069 1003 2837 
+Q 1156 2606 1428 2606 
+Q 1700 2606 1854 2837 
+Q 2009 3069 2009 3481 
+Q 2009 3884 1853 4118 
+Q 1697 4353 1428 4353 
+z
+M 4250 4750 
+L 4750 4750 
+L 1831 -91 
+L 1331 -91 
+L 4250 4750 
+z
+M 1428 4750 
+Q 1922 4750 2215 4408 
+Q 2509 4066 2509 3481 
+Q 2509 2891 2217 2550 
+Q 1925 2209 1428 2209 
+Q 931 2209 642 2551 
+Q 353 2894 353 3481 
+Q 353 4063 643 4406 
+Q 934 4750 1428 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-52"/>
+     <use xlink:href="#DejaVuSans-48" x="69.482422"/>
+     <use xlink:href="#DejaVuSans-20" x="144.677734"/>
+     <use xlink:href="#DejaVuSans-34" x="176.464844"/>
+     <use xlink:href="#DejaVuSans-30" x="240.087891"/>
+     <use xlink:href="#DejaVuSans-20" x="303.710938"/>
+     <use xlink:href="#DejaVuSans-25" x="335.498047"/>
+    </g>
+   </g>
+   <g id="label_constant_rh_data_60">
+    <!-- RH 60 % -->
+    <g style="fill: #005fbf; opacity: 0.525" transform="translate(901.9687 256.542991) rotate(-30.320365) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-52"/>
+     <use xlink:href="#DejaVuSans-48" x="69.482422"/>
+     <use xlink:href="#DejaVuSans-20" x="144.677734"/>
+     <use xlink:href="#DejaVuSans-36" x="176.464844"/>
+     <use xlink:href="#DejaVuSans-30" x="240.087891"/>
+     <use xlink:href="#DejaVuSans-20" x="303.710938"/>
+     <use xlink:href="#DejaVuSans-25" x="335.498047"/>
+    </g>
+   </g>
+   <g id="label_constant_wbt_data_15">
+    <!-- 15 °C -->
+    <g style="fill: #5fa7bf; opacity: 0.525" transform="translate(288.683196 300.771949) rotate(-340.821699) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-b0" d="M 1600 4347 
+Q 1350 4347 1178 4173 
+Q 1006 4000 1006 3750 
+Q 1006 3503 1178 3333 
+Q 1350 3163 1600 3163 
+Q 1850 3163 2022 3333 
+Q 2194 3503 2194 3750 
+Q 2194 3997 2020 4172 
+Q 1847 4347 1600 4347 
+z
+M 1600 4750 
+Q 1800 4750 1984 4673 
+Q 2169 4597 2303 4453 
+Q 2447 4313 2519 4134 
+Q 2591 3956 2591 3750 
+Q 2591 3338 2302 3052 
+Q 2013 2766 1594 2766 
+Q 1172 2766 890 3047 
+Q 609 3328 609 3750 
+Q 609 4169 896 4459 
+Q 1184 4750 1600 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-b0" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-43" x="209.033203"/>
+    </g>
+   </g>
+   <g id="label_constant_wbt_data_20">
+    <!-- 20 °C -->
+    <g style="fill: #5fa7bf; opacity: 0.525" transform="translate(672.692847 39.064843) rotate(-340.539937) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-b0" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-43" x="209.033203"/>
+    </g>
+   </g>
+   <g id="label_zone_dbt_rh_summer">
+    <g id="patch_1">
+     <path d="M 898.905937 340.46896 
+L 944.294062 340.46896 
+L 944.294062 324.558647 
+L 898.905937 324.558647 
+z
+" style="fill: #ffffff; fill-opacity: 0.4; stroke: #ffffff; stroke-opacity: 0.4; stroke-linejoin: miter"/>
+    </g>
+    <!-- Summer -->
+    <g transform="translate(902.505937 334.997241) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-75" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-6d" x="126.855469"/>
+     <use xlink:href="#DejaVuSans-6d" x="224.267578"/>
+     <use xlink:href="#DejaVuSans-65" x="321.679688"/>
+     <use xlink:href="#DejaVuSans-72" x="383.203125"/>
+    </g>
+   </g>
+   <g id="label_zone_dbt_rh_winter">
+    <g id="patch_2">
+     <path d="M 749.566875 497.163026 
+L 786.433125 497.163026 
+L 786.433125 481.252713 
+L 749.566875 481.252713 
+z
+" style="fill: #ffffff; fill-opacity: 0.4; stroke: #ffffff; stroke-opacity: 0.4; stroke-linejoin: miter"/>
+    </g>
+    <!-- Winter -->
+    <g transform="translate(753.166875 491.691307) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-57" d="M 213 4666 
+L 850 4666 
+L 1831 722 
+L 2809 4666 
+L 3519 4666 
+L 4500 722 
+L 5478 4666 
+L 6119 4666 
+L 4947 0 
+L 4153 0 
+L 3169 4050 
+L 2175 0 
+L 1381 0 
+L 213 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-57"/>
+     <use xlink:href="#DejaVuSans-69" x="96.626953"/>
+     <use xlink:href="#DejaVuSans-6e" x="124.410156"/>
+     <use xlink:href="#DejaVuSans-74" x="187.789062"/>
+     <use xlink:href="#DejaVuSans-65" x="226.998047"/>
+     <use xlink:href="#DejaVuSans-72" x="288.521484"/>
+    </g>
+   </g>
+   <g id="chart_legend">
+    <g id="line2d_12">
+     <path d="M 13.5 19.647656 
+L 28.5 19.647656 
+L 43.5 19.647656 
+" style="fill: none"/>
+     <defs>
+      <path id="mb5a178288b" d="M 0 3.2 
+C 0.84865 3.2 1.662656 2.862828 2.262742 2.262742 
+C 2.862828 1.662656 3.2 0.84865 3.2 0 
+C 3.2 -0.84865 2.862828 -1.662656 2.262742 -2.262742 
+C 1.662656 -2.862828 0.84865 -3.2 0 -3.2 
+C -0.84865 -3.2 -1.662656 -2.862828 -2.262742 -2.262742 
+C -2.862828 -1.662656 -3.2 -0.84865 -3.2 0 
+C -3.2 0.84865 -2.862828 1.662656 -2.262742 2.262742 
+C -1.662656 2.862828 -0.84865 3.2 0 3.2 
+z
+" style="stroke: #007bff; stroke-opacity: 0.9"/>
+     </defs>
+     <g>
+      <use xlink:href="#mb5a178288b" x="28.5" y="19.647656" style="fill: #007bff; fill-opacity: 0.9; stroke: #007bff; stroke-opacity: 0.9"/>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- Aseo -->
+     <g transform="translate(55.5 24.897656) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-41"/>
+      <use xlink:href="#DejaVuSans-73" x="68.408203"/>
+      <use xlink:href="#DejaVuSans-65" x="120.507812"/>
+      <use xlink:href="#DejaVuSans-6f" x="182.03125"/>
+     </g>
+    </g>
+    <g id="line2d_13">
+     <path d="M 13.5 46.164844 
+L 28.5 46.164844 
+L 43.5 46.164844 
+" style="fill: none"/>
+     <defs>
+      <path id="mf893ff4b0c" d="M 0 3.6 
+C 0.954731 3.6 1.870488 3.220681 2.545584 2.545584 
+C 3.220681 1.870488 3.6 0.954731 3.6 0 
+C 3.6 -0.954731 3.220681 -1.870488 2.545584 -2.545584 
+C 1.870488 -3.220681 0.954731 -3.6 0 -3.6 
+C -0.954731 -3.6 -1.870488 -3.220681 -2.545584 -2.545584 
+C -3.220681 -1.870488 -3.6 -0.954731 -3.6 0 
+C -3.6 0.954731 -3.220681 1.870488 -2.545584 2.545584 
+C -1.870488 3.220681 -0.954731 3.6 0 3.6 
+z
+" style="stroke: #f15346; stroke-opacity: 0.9"/>
+     </defs>
+     <g>
+      <use xlink:href="#mf893ff4b0c" x="28.5" y="46.164844" style="fill: #f15346; fill-opacity: 0.9; stroke: #f15346; stroke-opacity: 0.9"/>
+     </g>
+    </g>
+    <g id="text_13">
+     <!-- Cocina -->
+     <g transform="translate(55.5 51.414844) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-63" x="131.005859"/>
+      <use xlink:href="#DejaVuSans-69" x="185.986328"/>
+      <use xlink:href="#DejaVuSans-6e" x="213.769531"/>
+      <use xlink:href="#DejaVuSans-61" x="277.148438"/>
+     </g>
+    </g>
+    <g id="line2d_14">
+     <path d="M 13.5 72.682031 
+L 28.5 72.682031 
+L 43.5 72.682031 
+" style="fill: none"/>
+     <defs>
+      <path id="m58f8c7e10c" d="M 0 4 
+C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
+C 3.578535 2.078319 4 1.060812 4 0 
+C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
+C 2.078319 -3.578535 1.060812 -4 0 -4 
+C -1.060812 -4 -2.078319 -3.578535 -2.828427 -2.828427 
+C -3.578535 -2.078319 -4 -1.060812 -4 0 
+C -4 1.060812 -3.578535 2.078319 -2.828427 2.828427 
+C -2.078319 3.578535 -1.060812 4 0 4 
+z
+" style="stroke: #006400; stroke-opacity: 0.9"/>
+     </defs>
+     <g>
+      <use xlink:href="#m58f8c7e10c" x="28.5" y="72.682031" style="fill: #006400; fill-opacity: 0.9; stroke: #006400; stroke-opacity: 0.9"/>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Dormitorio (ESP) -->
+     <g transform="translate(55.5 77.932031) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 628 4666 
+L 3578 4666 
+L 3578 4134 
+L 1259 4134 
+L 1259 2753 
+L 3481 2753 
+L 3481 2222 
+L 1259 2222 
+L 1259 531 
+L 3634 531 
+L 3634 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-50" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-6f" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-72" x="138.183594"/>
+      <use xlink:href="#DejaVuSans-6d" x="177.546875"/>
+      <use xlink:href="#DejaVuSans-69" x="274.958984"/>
+      <use xlink:href="#DejaVuSans-74" x="302.742188"/>
+      <use xlink:href="#DejaVuSans-6f" x="341.951172"/>
+      <use xlink:href="#DejaVuSans-72" x="403.132812"/>
+      <use xlink:href="#DejaVuSans-69" x="444.246094"/>
+      <use xlink:href="#DejaVuSans-6f" x="472.029297"/>
+      <use xlink:href="#DejaVuSans-20" x="533.210938"/>
+      <use xlink:href="#DejaVuSans-28" x="564.998047"/>
+      <use xlink:href="#DejaVuSans-45" x="604.011719"/>
+      <use xlink:href="#DejaVuSans-53" x="667.195312"/>
+      <use xlink:href="#DejaVuSans-50" x="730.671875"/>
+      <use xlink:href="#DejaVuSans-29" x="790.974609"/>
+     </g>
+    </g>
+    <g id="line2d_15">
+     <path d="M 13.5 99.199219 
+L 28.5 99.199219 
+L 43.5 99.199219 
+" style="fill: none"/>
+     <defs>
+      <path id="m78b915f56e" d="M 0 4 
+C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
+C 3.578535 2.078319 4 1.060812 4 0 
+C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
+C 2.078319 -3.578535 1.060812 -4 0 -4 
+C -1.060812 -4 -2.078319 -3.578535 -2.828427 -2.828427 
+C -3.578535 -2.078319 -4 -1.060812 -4 0 
+C -4 1.060812 -3.578535 2.078319 -2.828427 2.828427 
+C -2.078319 3.578535 -1.060812 4 0 4 
+z
+" style="stroke: #51e81f; stroke-opacity: 0.9"/>
+     </defs>
+     <g>
+      <use xlink:href="#m78b915f56e" x="28.5" y="99.199219" style="fill: #51e81f; fill-opacity: 0.9; stroke: #51e81f; stroke-opacity: 0.9"/>
+     </g>
+    </g>
+    <g id="text_15">
+     <!-- Dormitorio -->
+     <g transform="translate(55.5 104.449219) scale(0.15 -0.15)">
+      <use xlink:href="#DejaVuSans-44"/>
+      <use xlink:href="#DejaVuSans-6f" x="77.001953"/>
+      <use xlink:href="#DejaVuSans-72" x="138.183594"/>
+      <use xlink:href="#DejaVuSans-6d" x="177.546875"/>
+      <use xlink:href="#DejaVuSans-69" x="274.958984"/>
+      <use xlink:href="#DejaVuSans-74" x="302.742188"/>
+      <use xlink:href="#DejaVuSans-6f" x="341.951172"/>
+      <use xlink:href="#DejaVuSans-72" x="403.132812"/>
+      <use xlink:href="#DejaVuSans-69" x="444.246094"/>
+      <use xlink:href="#DejaVuSans-6f" x="472.029297"/>
+     </g>
+    </g>
+    <g id="line2d_16">
+     <path d="M 13.5 125.716406 
+L 28.5 125.716406 
+L 43.5 125.716406 
+" style="fill: none"/>
+     <defs>
+      <path id="m276908cdbe" d="M 0 3.6 
+C 0.954731 3.6 1.870488 3.220681 2.545584 2.545584 
+C 3.220681 1.870488 3.6 0.954731 3.6 0 
+C 3.6 -0.954731 3.220681 -1.870488 2.545584 -2.545584 
+C 1.870488 -3.220681 0.954731 -3.6 0 -3.6 
+C -0.954731 -3.6 -1.870488 -3.220681 -2.545584 -2.545584 
+C -3.220681 -1.870488 -3.6 -0.954731 -3.6 0 
+C -3.6 0.954731 -3.220681 1.870488 -2.545584 2.545584 
+C -1.870488 3.220681 -0.954731 3.6 0 3.6 
+z
+" style="stroke: #ffa067; stroke-opacity: 0.9"/>
+     </defs>
+     <g>
+      <use xlink:href="#m276908cdbe" x="28.5" y="125.716406" style="fill: #ffa067; fill-opacity: 0.9; stroke: #ffa067; stroke-opacity: 0.9"/>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- Estudio -->
+     <g transform="translate(55.5 130.966406) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-45"/>
+      <use xlink:href="#DejaVuSans-73" x="63.183594"/>
+      <use xlink:href="#DejaVuSans-74" x="115.283203"/>
+      <use xlink:href="#DejaVuSans-75" x="154.492188"/>
+      <use xlink:href="#DejaVuSans-64" x="217.871094"/>
+      <use xlink:href="#DejaVuSans-69" x="281.347656"/>
+      <use xlink:href="#DejaVuSans-6f" x="309.130859"/>
+     </g>
+    </g>
+    <g id="line2d_17">
+     <path d="M 13.5 152.233594 
+L 28.5 152.233594 
+L 43.5 152.233594 
+" style="fill: none"/>
+     <defs>
+      <path id="m72495f34b2" d="M 0 4.8 
+C 1.272975 4.8 2.493983 4.294242 3.394113 3.394113 
+C 4.294242 2.493983 4.8 1.272975 4.8 0 
+C 4.8 -1.272975 4.294242 -2.493983 3.394113 -3.394113 
+C 2.493983 -4.294242 1.272975 -4.8 0 -4.8 
+C -1.272975 -4.8 -2.493983 -4.294242 -3.394113 -3.394113 
+C -4.294242 -2.493983 -4.8 -1.272975 -4.8 0 
+C -4.8 1.272975 -4.294242 2.493983 -3.394113 3.394113 
+C -2.493983 4.294242 -1.272975 4.8 0 4.8 
+z
+" style="stroke: #bb1247; stroke-opacity: 0.9"/>
+     </defs>
+     <g>
+      <use xlink:href="#m72495f34b2" x="28.5" y="152.233594" style="fill: #bb1247; fill-opacity: 0.9; stroke: #bb1247; stroke-opacity: 0.9"/>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- Office -->
+     <g transform="translate(55.5 157.483594) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4f"/>
+      <use xlink:href="#DejaVuSans-66" x="78.710938"/>
+      <use xlink:href="#DejaVuSans-66" x="113.916016"/>
+      <use xlink:href="#DejaVuSans-69" x="149.121094"/>
+      <use xlink:href="#DejaVuSans-63" x="176.904297"/>
+      <use xlink:href="#DejaVuSans-65" x="231.884766"/>
+     </g>
+    </g>
+    <g id="line2d_18">
+     <path d="M 13.5 178.750781 
+L 28.5 178.750781 
+L 43.5 178.750781 
+" style="fill: none"/>
+     <defs>
+      <path id="m1f0e77f4bf" d="M 0 4.8 
+C 1.272975 4.8 2.493983 4.294242 3.394113 3.394113 
+C 4.294242 2.493983 4.8 1.272975 4.8 0 
+C 4.8 -1.272975 4.294242 -2.493983 3.394113 -3.394113 
+C 2.493983 -4.294242 1.272975 -4.8 0 -4.8 
+C -1.272975 -4.8 -2.493983 -4.294242 -3.394113 -3.394113 
+C -4.294242 -2.493983 -4.8 -1.272975 -4.8 0 
+C -4.8 1.272975 -4.294242 2.493983 -3.394113 3.394113 
+C -2.493983 4.294242 -1.272975 4.8 0 4.8 
+z
+" style="stroke: #bb2b1e; stroke-opacity: 0.9"/>
+     </defs>
+     <g>
+      <use xlink:href="#m1f0e77f4bf" x="28.5" y="178.750781" style="fill: #bb2b1e; fill-opacity: 0.9; stroke: #bb2b1e; stroke-opacity: 0.9"/>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Office-Window -->
+     <g transform="translate(55.5 184.000781) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4f"/>
+      <use xlink:href="#DejaVuSans-66" x="78.710938"/>
+      <use xlink:href="#DejaVuSans-66" x="113.916016"/>
+      <use xlink:href="#DejaVuSans-69" x="149.121094"/>
+      <use xlink:href="#DejaVuSans-63" x="176.904297"/>
+      <use xlink:href="#DejaVuSans-65" x="231.884766"/>
+      <use xlink:href="#DejaVuSans-2d" x="293.408203"/>
+      <use xlink:href="#DejaVuSans-57" x="325.492188"/>
+      <use xlink:href="#DejaVuSans-69" x="422.119141"/>
+      <use xlink:href="#DejaVuSans-6e" x="449.902344"/>
+      <use xlink:href="#DejaVuSans-64" x="513.28125"/>
+      <use xlink:href="#DejaVuSans-6f" x="576.757812"/>
+      <use xlink:href="#DejaVuSans-77" x="637.939453"/>
+     </g>
+    </g>
+    <g id="line2d_19">
+     <path d="M 13.5 205.267969 
+L 28.5 205.267969 
+L 43.5 205.267969 
+" style="fill: none"/>
+     <defs>
+      <path id="mcafc8a7f9e" d="M 0 4 
+C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
+C 3.578535 2.078319 4 1.060812 4 0 
+C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
+C 2.078319 -3.578535 1.060812 -4 0 -4 
+C -1.060812 -4 -2.078319 -3.578535 -2.828427 -2.828427 
+C -3.578535 -2.078319 -4 -1.060812 -4 0 
+C -4 1.060812 -3.578535 2.078319 -2.828427 2.828427 
+C -2.078319 3.578535 -1.060812 4 0 4 
+z
+" style="stroke: #e3db55; stroke-opacity: 0.8"/>
+     </defs>
+     <g>
+      <use xlink:href="#mcafc8a7f9e" x="28.5" y="205.267969" style="fill: #e3db55; fill-opacity: 0.8; stroke: #e3db55; stroke-opacity: 0.8"/>
+     </g>
+    </g>
+    <g id="text_19">
+     <!-- Sofa -->
+     <g transform="translate(55.5 210.517969) scale(0.15 -0.15)">
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-6f" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-66" x="124.658203"/>
+      <use xlink:href="#DejaVuSans-61" x="159.863281"/>
+     </g>
+    </g>
+    <g id="line2d_20">
+     <path d="M 13.5 231.785156 
+L 28.5 231.785156 
+L 43.5 231.785156 
+" style="fill: none"/>
+     <defs>
+      <path id="m1547987c79" d="M 0 4.4 
+C 1.166894 4.4 2.286151 3.936388 3.11127 3.11127 
+C 3.936388 2.286151 4.4 1.166894 4.4 0 
+C 4.4 -1.166894 3.936388 -2.286151 3.11127 -3.11127 
+C 2.286151 -3.936388 1.166894 -4.4 0 -4.4 
+C -1.166894 -4.4 -2.286151 -3.936388 -3.11127 -3.11127 
+C -3.936388 -2.286151 -4.4 -1.166894 -4.4 0 
+C -4.4 1.166894 -3.936388 2.286151 -3.11127 3.11127 
+C -2.286151 3.936388 -1.166894 4.4 0 4.4 
+z
+" style="stroke: #fb6150; stroke-opacity: 0.9"/>
+     </defs>
+     <g>
+      <use xlink:href="#m1547987c79" x="28.5" y="231.785156" style="fill: #fb6150; fill-opacity: 0.9; stroke: #fb6150; stroke-opacity: 0.9"/>
+     </g>
+    </g>
+    <g id="text_20">
+     <!-- Galeria (sombra) -->
+     <g transform="translate(55.5 237.035156) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-47"/>
+      <use xlink:href="#DejaVuSans-61" x="77.490234"/>
+      <use xlink:href="#DejaVuSans-6c" x="138.769531"/>
+      <use xlink:href="#DejaVuSans-65" x="166.552734"/>
+      <use xlink:href="#DejaVuSans-72" x="228.076172"/>
+      <use xlink:href="#DejaVuSans-69" x="269.189453"/>
+      <use xlink:href="#DejaVuSans-61" x="296.972656"/>
+      <use xlink:href="#DejaVuSans-20" x="358.251953"/>
+      <use xlink:href="#DejaVuSans-28" x="390.039062"/>
+      <use xlink:href="#DejaVuSans-73" x="429.052734"/>
+      <use xlink:href="#DejaVuSans-6f" x="481.152344"/>
+      <use xlink:href="#DejaVuSans-6d" x="542.333984"/>
+      <use xlink:href="#DejaVuSans-62" x="639.746094"/>
+      <use xlink:href="#DejaVuSans-72" x="703.222656"/>
+      <use xlink:href="#DejaVuSans-61" x="744.335938"/>
+      <use xlink:href="#DejaVuSans-29" x="805.615234"/>
+     </g>
+    </g>
+    <g id="line2d_21">
+     <path d="M 13.5 258.302344 
+L 28.5 258.302344 
+L 43.5 258.302344 
+" style="fill: none"/>
+     <defs>
+      <path id="mc6feed0b26" d="M 0 4.8 
+C 1.272975 4.8 2.493983 4.294242 3.394113 3.394113 
+C 4.294242 2.493983 4.8 1.272975 4.8 0 
+C 4.8 -1.272975 4.294242 -2.493983 3.394113 -3.394113 
+C 2.493983 -4.294242 1.272975 -4.8 0 -4.8 
+C -1.272975 -4.8 -2.493983 -4.294242 -3.394113 -3.394113 
+C -4.294242 -2.493983 -4.8 -1.272975 -4.8 0 
+C -4.8 1.272975 -4.294242 2.493983 -3.394113 3.394113 
+C -2.493983 4.294242 -1.272975 4.8 0 4.8 
+z
+" style="stroke: #e37207; stroke-opacity: 0.7"/>
+     </defs>
+     <g>
+      <use xlink:href="#mc6feed0b26" x="28.5" y="258.302344" style="fill: #e37207; fill-opacity: 0.7; stroke: #e37207; stroke-opacity: 0.7"/>
+     </g>
+    </g>
+    <g id="text_21">
+     <!-- Terraza -->
+     <g transform="translate(55.5 263.552344) scale(0.15 -0.15)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-65" x="44.083984"/>
+      <use xlink:href="#DejaVuSans-72" x="105.607422"/>
+      <use xlink:href="#DejaVuSans-72" x="144.970703"/>
+      <use xlink:href="#DejaVuSans-61" x="186.083984"/>
+      <use xlink:href="#DejaVuSans-7a" x="247.363281"/>
+      <use xlink:href="#DejaVuSans-61" x="299.853516"/>
+     </g>
+    </g>
+    <g id="line2d_22">
+     <path d="M 13.5 284.819531 
+L 28.5 284.819531 
+L 43.5 284.819531 
+" style="fill: none"/>
+     <defs>
+      <path id="m059662e0b1" d="M 0 4.4 
+C 1.166894 4.4 2.286151 3.936388 3.11127 3.11127 
+C 3.936388 2.286151 4.4 1.166894 4.4 0 
+C 4.4 -1.166894 3.936388 -2.286151 3.11127 -3.11127 
+C 2.286151 -3.936388 1.166894 -4.4 0 -4.4 
+C -1.166894 -4.4 -2.286151 -3.936388 -3.11127 -3.11127 
+C -3.936388 -2.286151 -4.4 -1.166894 -4.4 0 
+C -4.4 1.166894 -3.936388 2.286151 -3.11127 3.11127 
+C -2.286151 3.936388 -1.166894 4.4 0 4.4 
+z
+" style="stroke: #cc9706; stroke-opacity: 0.9"/>
+     </defs>
+     <g>
+      <use xlink:href="#m059662e0b1" x="28.5" y="284.819531" style="fill: #cc9706; fill-opacity: 0.9; stroke: #cc9706; stroke-opacity: 0.9"/>
+     </g>
+    </g>
+    <g id="text_22">
+     <!-- Terraza (sombra) -->
+     <g transform="translate(55.5 290.069531) scale(0.15 -0.15)">
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-65" x="44.083984"/>
+      <use xlink:href="#DejaVuSans-72" x="105.607422"/>
+      <use xlink:href="#DejaVuSans-72" x="144.970703"/>
+      <use xlink:href="#DejaVuSans-61" x="186.083984"/>
+      <use xlink:href="#DejaVuSans-7a" x="247.363281"/>
+      <use xlink:href="#DejaVuSans-61" x="299.853516"/>
+      <use xlink:href="#DejaVuSans-20" x="361.132812"/>
+      <use xlink:href="#DejaVuSans-28" x="392.919922"/>
+      <use xlink:href="#DejaVuSans-73" x="431.933594"/>
+      <use xlink:href="#DejaVuSans-6f" x="484.033203"/>
+      <use xlink:href="#DejaVuSans-6d" x="545.214844"/>
+      <use xlink:href="#DejaVuSans-62" x="642.626953"/>
+      <use xlink:href="#DejaVuSans-72" x="706.103516"/>
+      <use xlink:href="#DejaVuSans-61" x="747.216797"/>
+      <use xlink:href="#DejaVuSans-29" x="808.496094"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p411d26f6a5">
+   <rect x="0" y="0" width="1152" height="648"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/tests/test_ha_addon_chart.py
+++ b/tests/test_ha_addon_chart.py
@@ -312,3 +312,54 @@ def test_ha_addon_psychrochart():
         frameon=False, fontsize=15, labelspacing=0.8, markerscale=0.8
     )
     store_test_chart(chart, "test_ha_addon_psychrochart-3.svg", png=True)
+
+
+def test_bad_convex_hull():
+    set_unit_system()
+    chart_config = TEST_EXAMPLE_CHART_CONFIG.copy()
+    t_min, t_max, w_min, w_max = _get_dynamic_limits(_EXAMPLE_SENSOR_POINTS)
+    chart_config["limits"].update(  # type: ignore[attr-defined]
+        {
+            "range_temp_c": (t_min, t_max),
+            "range_humidity_g_kg": (w_min, w_max),
+        }
+    )
+    chart = PsychroChart.create(chart_config)
+
+    points = {
+        "Aseo": {
+            "xy": (20.63, 55.86),
+            "label": "Aseo",
+            "style": {"color": "#007bff", "alpha": 0.9, "markersize": 8},
+        },
+        "Cocina": {
+            "xy": (20.15, 55.38),
+            "label": "Cocina",
+            "style": {"alpha": 0.9, "color": "#F15346", "markersize": 9},
+        },
+        "Dormitorio (ESP)": {
+            "xy": (20.15, 55.38),
+            "label": "Dormitorio (ESP)",
+            "style": {"alpha": 0.9, "color": "darkgreen", "markersize": 10},
+        },
+        "Dormitorio": {
+            "xy": (20.63, 55.86),
+            "label": "Dormitorio",
+            "style": {"alpha": 0.9, "color": "#51E81F", "markersize": 10},
+        },
+        "Estudio": {
+            "xy": (20.15, 55.38),
+            "label": "Estudio",
+            "style": {"alpha": 0.9, "color": "#FFA067", "markersize": 9},
+        },
+    }
+    zones = [
+        (
+            ["Aseo", "Cocina", "Dormitorio (ESP)", "Dormitorio"],
+            {"color": "#E37207", "lw": 1, "alpha": 0.5, "ls": "--"},
+            {"color": "#E37207", "lw": 0, "alpha": 0.2},
+        ),
+    ]
+
+    chart.plot_points_dbt_rh(points, convex_groups=zones)
+    store_test_chart(chart, "test_bad_hull.svg", png=True, svg_rsc=True)

--- a/tests/test_ha_addon_chart.py
+++ b/tests/test_ha_addon_chart.py
@@ -1,0 +1,314 @@
+from math import ceil, floor
+from typing import Any
+
+from psychrochart import PsychroChart
+from psychrochart.chartdata import (
+    gen_points_in_constant_relative_humidity,
+)
+from psychrochart.models.annots import ChartAnnots, ChartArea
+from psychrochart.plot_logic import plot_annots_dbt_rh
+from psychrochart.process_logic import set_unit_system
+from tests.conftest import store_test_chart
+
+_MIN_CHART_TEMPERATURE = 20
+_MAX_CHART_TEMPERATURE = 27
+# fmt: off
+TEST_EXAMPLE_ZONES = [
+    {
+        "label": "Summer",
+        "points_x": [23, 28],
+        "points_y": [40, 60],
+        "style": {
+            "edgecolor": [1.0, 0.749, 0.0, 0.8],
+            "facecolor": [1.0, 0.749, 0.0, 0.2],
+            "linestyle": "--",
+            "linewidth": 2,
+        },
+        "zone_type": "dbt-rh",
+    },
+    {
+        "label": "Winter",
+        "points_x": [18, 23],
+        "points_y": [35, 55],
+        "style": {
+            "edgecolor": [0.498, 0.624, 0.8],
+            "facecolor": [0.498, 0.624, 1.0, 0.2],
+            "linestyle": "--",
+            "linewidth": 2,
+        },
+        "zone_type": "dbt-rh",
+    },
+]
+TEST_EXAMPLE_FIG_CONFIG = {
+    "figsize": [16, 9],
+    "partial_axis": True,
+    "position": [0, 0, 1, 1],
+    "title": None,
+    "x_axis": {
+        "color": [0.855, 0.145, 0.114],
+        "linestyle": "-",
+        "linewidth": 2,
+    },
+    "x_axis_labels": {"color": [0.855, 0.145, 0.114], "fontsize": 10},
+    "x_axis_ticks": {
+        "color": [0.855, 0.145, 0.114],
+        "direction": "in",
+        "pad": -20,
+    },
+    "x_label": None,
+    "y_axis": {
+        "color": [0.0, 0.125, 0.376],
+        "linestyle": "-",
+        "linewidth": 2,
+    },
+    "y_axis_labels": {"color": [0.0, 0.125, 0.376], "fontsize": 10},
+    "y_axis_ticks": {
+        "color": [0.0, 0.125, 0.376],
+        "direction": "in",
+        "pad": -20,
+    },
+    "y_label": None,
+}
+# fmt: on
+
+TEST_EXAMPLE_CHART_CONFIG = {
+    "chart_params": {
+        "constant_h_label": None,
+        "constant_h_labels": [25, 50, 75],
+        "constant_h_step": 5,
+        "constant_humid_label": None,
+        "constant_humid_label_include_limits": False,
+        "constant_humid_label_step": 1,
+        "constant_humid_step": 0.5,
+        "constant_rh_curves": [20, 40, 50, 60, 80],
+        "constant_rh_label": None,
+        "constant_rh_labels": [20, 40, 60],
+        "constant_rh_labels_loc": 0.8,
+        "constant_temp_label": None,
+        "constant_temp_label_include_limits": False,
+        "constant_temp_label_step": 5,
+        "constant_temp_step": 5,
+        "constant_v_label": None,
+        "constant_v_labels": [0.82, 0.84, 0.86, 0.88],
+        "constant_v_labels_loc": 0.01,
+        "constant_v_step": 0.01,
+        "constant_wet_temp_label": None,
+        "constant_wet_temp_labels": [10, 15, 20],
+        "constant_wet_temp_step": 5,
+        "range_wet_temp": [15, 25],
+        "range_h": [25, 85],
+        "range_vol_m3_kg": [0.82, 0.88],
+        "with_constant_dry_temp": True,
+        "with_constant_h": True,
+        "with_constant_humidity": True,
+        "with_constant_rh": True,
+        "with_constant_v": True,
+        "with_constant_wet_temp": True,
+        "with_zones": True,
+    },
+    "constant_dry_temp": {
+        "color": [0.855, 0.145, 0.114, 0.7],
+        "linestyle": ":",
+        "linewidth": 0.75,
+    },
+    "constant_h": {
+        "color": [0.251, 0.0, 0.502, 0.7],
+        "linestyle": "-",
+        "linewidth": 2,
+    },
+    "constant_humidity": {
+        "color": [0.0, 0.125, 0.376, 0.7],
+        "linestyle": ":",
+        "linewidth": 0.75,
+    },
+    "constant_rh": {
+        "color": [0.0, 0.498, 1.0, 0.7],
+        "linestyle": "-.",
+        "linewidth": 2,
+    },
+    "constant_v": {
+        "color": [0.0, 0.502, 0.337, 0.7],
+        "linestyle": "-",
+        "linewidth": 1,
+    },
+    "constant_wet_temp": {
+        "color": [0.498, 0.875, 1.0, 0.7],
+        "linestyle": "-",
+        "linewidth": 1,
+    },
+    "figure": TEST_EXAMPLE_FIG_CONFIG,
+    "limits": {
+        "range_humidity_g_kg": [0, 3],
+        "range_temp_c": [-30, 10],
+        "step_temp": 0.5,
+        "pressure_kpa": 101.42,
+    },
+    "saturation": {
+        "color": [0.855, 0.145, 0.114],
+        "linestyle": "-",
+        "linewidth": 5,
+    },
+    "zones": TEST_EXAMPLE_ZONES,
+}
+
+_EXAMPLE_SENSOR_POINTS = {
+    "Aseo": {
+        "xy": (20.63, 55.86),
+        "label": "Aseo",
+        "style": {"color": "#007bff", "alpha": 0.9, "markersize": 8},
+    },
+    "Cocina": {
+        "xy": (20.15, 55.38),
+        "label": "Cocina",
+        "style": {"alpha": 0.9, "color": "#F15346", "markersize": 9},
+    },
+    "Dormitorio (ESP)": {
+        "xy": (20.0, 59.1),
+        "label": "Dormitorio (ESP)",
+        "style": {"alpha": 0.9, "color": "darkgreen", "markersize": 10},
+    },
+    "Dormitorio": {
+        "xy": (19.56, 61.84),
+        "label": "Dormitorio",
+        "style": {"alpha": 0.9, "color": "#51E81F", "markersize": 10},
+    },
+    "Estudio": {
+        "xy": (20.7, 55.4),
+        "label": "Estudio",
+        "style": {"alpha": 0.9, "color": "#FFA067", "markersize": 9},
+    },
+    "Office": {
+        "xy": (20.8, 53.0),
+        "label": "Office",
+        "style": {"alpha": 0.9, "color": "#bb1247", "markersize": 12},
+    },
+    "Office-Window": {
+        "xy": (20.36, 64.33),
+        "label": "Office-Window",
+        "style": {"alpha": 0.9, "color": "#bb2b1e", "markersize": 12},
+    },
+    "Sofa": {
+        "xy": (22.12, 52.07),
+        "label": "Sofa",
+        "style": {"alpha": 0.8, "color": "#E3DB55", "markersize": 10},
+    },
+    "Galeria (sombra)": {
+        "xy": (15.51, 85.57),
+        "label": "Galeria (sombra)",
+        "style": {"alpha": 0.9, "color": "#fb6150", "markersize": 11},
+    },
+    "Terraza": {
+        "xy": (17.1, 99.6),
+        "label": "Terraza",
+        "style": {"alpha": 0.7, "color": "#E37207", "markersize": 12},
+    },
+    "Terraza (sombra)": {
+        "xy": (15.89, 85.48),
+        "label": "Terraza (sombra)",
+        "style": {"alpha": 0.9, "color": "#CC9706", "markersize": 11},
+    },
+}
+_EXAMPLE_SENSOR_ZONES = [
+    (
+        [
+            "Aseo",
+            "Cocina",
+            "Dormitorio (ESP)",
+            "Dormitorio",
+            "Estudio",
+            "Office",
+            "Office-Window",
+            "Sofa",
+        ],
+        {"color": "darkgreen", "lw": 2, "alpha": 0.5, "ls": ":"},
+        {"color": "green", "lw": 0, "alpha": 0.3},
+    ),
+    (
+        ["Galeria (sombra)", "Terraza", "Terraza (sombra)"],
+        {"color": "#E37207", "lw": 1, "alpha": 0.5, "ls": "--"},
+        {"color": "#E37207", "lw": 0, "alpha": 0.2},
+    ),
+]
+
+
+def _get_dynamic_limits(points: dict[str, Any], pressure: float = 101325.0):
+    pairs_t_rh = [point["xy"] for point in points.values()]
+    values_t = [p[0] for p in pairs_t_rh]
+    values_w = gen_points_in_constant_relative_humidity(
+        values_t, [p[1] for p in pairs_t_rh], pressure
+    )
+
+    min_temp = min(floor((min(values_t) - 1) / 3) * 3, _MIN_CHART_TEMPERATURE)
+    max_temp = max(ceil((max(values_t) + 1) / 3) * 3, _MAX_CHART_TEMPERATURE)
+    w_min = min(floor((min(values_w) - 1) / 3) * 3, 5.0)
+    w_max = ceil(max(values_w)) + 2
+    return min_temp, max_temp, w_min, w_max
+
+
+def test_ha_addon_psychrochart():
+    set_unit_system()
+    chart_config = TEST_EXAMPLE_CHART_CONFIG.copy()
+    t_min, t_max, w_min, w_max = _get_dynamic_limits(_EXAMPLE_SENSOR_POINTS)
+    chart_config["limits"].update(  # type: ignore[attr-defined]
+        {
+            "range_temp_c": (t_min, t_max),
+            "range_humidity_g_kg": (w_min, w_max),
+        }
+    )
+    chart = PsychroChart.create(chart_config)
+    chart.append_zones()
+    chart_annots = chart.plot_points_dbt_rh(
+        _EXAMPLE_SENSOR_POINTS, convex_groups=_EXAMPLE_SENSOR_ZONES
+    )
+    assert isinstance(chart_annots, ChartAnnots)
+    chart.plot_legend(
+        frameon=False, fontsize=15, labelspacing=0.8, markerscale=0.8
+    )
+    store_test_chart(
+        chart, "test_ha_addon_psychrochart.svg", png=True, svg_rsc=True
+    )
+
+    chart_annots.areas.pop(0)
+    chart_annots.areas.append(
+        ChartArea(
+            point_names=[
+                "Galeria (sombra)",
+                "Aseo",
+                "Cocina",
+                "Dormitorio (ESP)",
+                "Dormitorio",
+                "Estudio",
+                "Office",
+                "Terraza (sombra)",
+            ],
+            line_style={"color": "#c335e3", "lw": 1, "alpha": 0.5, "ls": "--"},
+            fill_style={"color": "#aa89e3", "lw": 0, "alpha": 0.2},
+        )
+    )
+    chart.plot()
+    plot_annots_dbt_rh(chart.axes, chart_annots)
+    chart.plot_legend(
+        frameon=False, fontsize=15, labelspacing=0.8, markerscale=0.8
+    )
+    store_test_chart(chart, "test_ha_addon_psychrochart-2.svg", png=True)
+
+    chart_annots.areas = [
+        ChartArea(
+            point_names=[
+                "Sofa",
+                "Terraza",
+                "Cocina",
+                "Dormitorio (ESP)",
+                "Office-Window",
+                "Dormitorio",
+            ],
+            line_style={"color": "#50e341", "lw": 1, "alpha": 0.5, "ls": "--"},
+            fill_style={"color": "#89e396", "lw": 0, "alpha": 0.2},
+        )
+    ]
+    chart.plot()
+    plot_annots_dbt_rh(chart.axes, chart_annots)
+    chart.plot_legend(
+        frameon=False, fontsize=15, labelspacing=0.8, markerscale=0.8
+    )
+    store_test_chart(chart, "test_ha_addon_psychrochart-3.svg", png=True)


### PR DESCRIPTION
Follow up #58, this time removing `scipy` dependency, as it was an overkill for the usages here.

##### Changes

- ⚡️ Use simple 1D interpolator to project points instead of `scipy.interpolate.interp1d`
- ✅ Add tests for convex hulls of given points
- ⚡️ Use simple convex hull algorithm, to compute zones to group annotated points, instead of using `scipy.spatial.ConvexHull`
- 📦️ Bump version, removing `scipy` dependency